### PR TITLE
Moved TenantConfiguration to multitenancy module

### DIFF
--- a/multitenancy-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/multitenancy/autoconfig/MultiTenancyAutoConfiguration.java
+++ b/multitenancy-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/multitenancy/autoconfig/MultiTenancyAutoConfiguration.java
@@ -37,7 +37,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 
-import static org.axonframework.extensions.multitenancy.autoconfig.TenantConfiguration.TENANT_CORRELATION_KEY;
+import static org.axonframework.extensions.multitenancy.configuration.TenantConfiguration.TENANT_CORRELATION_KEY;
+
 
 /**
  * Configures Axon Server as implementation for multi-tenant components like CommandBus, QueryBus and EventStore.

--- a/multitenancy/src/main/java/org/axonframework/extensions/multitenancy/configuration/TenantConfiguration.java
+++ b/multitenancy/src/main/java/org/axonframework/extensions/multitenancy/configuration/TenantConfiguration.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.axonframework.extensions.multitenancy.autoconfig;
+package org.axonframework.extensions.multitenancy.configuration;
 
 /**
  * Enables static access to default {@code TENANT_CORRELATION_KEY} used to correlate tenant identifiers within {@link


### PR DESCRIPTION
To be able to use the TenantConfiguration it needs to be moved to the multitenancy module.