### PR TITLE
[#93] Replace `@PostConstruct` for `Lifecycle` wiring

### DIFF
--- a/multitenancy-spring-boot-3-integrationtests/src/test/java/org/axonframework/extensions/multitenancy/integration/MultiTenancyIntegrationTest.java
+++ b/multitenancy-spring-boot-3-integrationtests/src/test/java/org/axonframework/extensions/multitenancy/integration/MultiTenancyIntegrationTest.java
@@ -16,14 +16,13 @@
 
 package org.axonframework.extensions.multitenancy.integration;
 
+import org.axonframework.axonserver.connector.AxonServerConfiguration;
 import org.axonframework.commandhandling.CommandBus;
 import org.axonframework.commandhandling.CommandMessage;
 import org.axonframework.commandhandling.GenericCommandMessage;
-import org.axonframework.eventsourcing.eventstore.EventStore;
 import org.axonframework.extensions.multitenancy.components.NoSuchTenantException;
 import org.axonframework.extensions.multitenancy.components.TenantDescriptor;
 import org.axonframework.extensions.multitenancy.components.commandhandeling.MultiTenantCommandBus;
-import org.axonframework.extensions.multitenancy.components.eventstore.MultiTenantEventStore;
 import org.axonframework.extensions.multitenancy.components.queryhandeling.MultiTenantQueryBus;
 import org.axonframework.extensions.multitenancy.components.queryhandeling.MultiTenantQueryUpdateEmitter;
 import org.axonframework.messaging.GenericMessage;
@@ -122,6 +121,27 @@ class MultiTenancyIntegrationTest {
                     assertNotNull(queryBus);
                     assertTrue(queryBus instanceof MultiTenantQueryBus);
                     executeQueryWhileTenantNotSet(queryBus);
+                });
+    }
+
+    @Test
+    void heartBeatDisabled() {
+        testApplicationContext
+                .run(context -> {
+                    AxonServerConfiguration axonServerConfiguration = context.getBean(AxonServerConfiguration.class);
+                    assertNotNull(axonServerConfiguration);
+                    assertFalse(axonServerConfiguration.getHeartbeat().isEnabled());
+                });
+    }
+
+    @Test
+    void heartBeatEnabled() {
+        testApplicationContext
+                .withPropertyValues("axon.axonserver.heartbeat.enabled=true")
+                .run(context -> {
+                    AxonServerConfiguration axonServerConfiguration = context.getBean(AxonServerConfiguration.class);
+                    assertNotNull(axonServerConfiguration);
+                    assertTrue(axonServerConfiguration.getHeartbeat().isEnabled());
                 });
     }
 

--- a/multitenancy-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/multitenancy/autoconfig/AxonServerTenantProvider.java
+++ b/multitenancy-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/multitenancy/autoconfig/AxonServerTenantProvider.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,6 +25,8 @@ import org.axonframework.extensions.multitenancy.components.MultiTenantAwareComp
 import org.axonframework.extensions.multitenancy.components.TenantConnectPredicate;
 import org.axonframework.extensions.multitenancy.components.TenantDescriptor;
 import org.axonframework.extensions.multitenancy.components.TenantProvider;
+import org.axonframework.lifecycle.Lifecycle;
+import org.axonframework.lifecycle.Phase;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,7 +39,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
-import javax.annotation.PostConstruct;
+import javax.annotation.Nonnull;
 
 /**
  * Axon Server implementation of {@link TenantProvider}
@@ -45,7 +47,7 @@ import javax.annotation.PostConstruct;
  * @author Stefan Dragisic
  * @since 4.6.0
  */
-public class AxonServerTenantProvider implements TenantProvider {
+public class AxonServerTenantProvider implements TenantProvider, Lifecycle {
 
     private static final Logger logger = LoggerFactory.getLogger(AxonServerTenantProvider.class);
 
@@ -66,7 +68,6 @@ public class AxonServerTenantProvider implements TenantProvider {
         this.axonServerConnectionManager = axonServerConnectionManager;
     }
 
-    @PostConstruct
     public void start() {
         tenantDescriptors.addAll(getInitialTenants());
         if (preDefinedContexts == null || preDefinedContexts.isEmpty()) {
@@ -194,5 +195,10 @@ public class AxonServerTenantProvider implements TenantProvider {
             registrationMap = new ConcurrentHashMap<>();
             return true;
         };
+    }
+
+    @Override
+    public void registerLifecycleHandlers(@Nonnull LifecycleRegistry lifecycle) {
+        lifecycle.onStart(Phase.INSTRUCTION_COMPONENTS + 10, this::start);
     }
 }

--- a/multitenancy-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/multitenancy/autoconfig/AxonServerTenantProvider.java
+++ b/multitenancy-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/multitenancy/autoconfig/AxonServerTenantProvider.java
@@ -70,6 +70,7 @@ public class AxonServerTenantProvider implements TenantProvider, Lifecycle {
 
     public void start() {
         tenantDescriptors.addAll(getInitialTenants());
+        tenantDescriptors.forEach(this::addTenant);
         if (preDefinedContexts == null || preDefinedContexts.isEmpty()) {
             subscribeToUpdates();
         }

--- a/multitenancy-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/multitenancy/autoconfig/CloudTenantProvider.java
+++ b/multitenancy-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/multitenancy/autoconfig/CloudTenantProvider.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2023. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,6 +25,8 @@ import org.axonframework.extensions.multitenancy.components.MultiTenantAwareComp
 import org.axonframework.extensions.multitenancy.components.TenantConnectPredicate;
 import org.axonframework.extensions.multitenancy.components.TenantDescriptor;
 import org.axonframework.extensions.multitenancy.components.TenantProvider;
+import org.axonframework.lifecycle.Lifecycle;
+import org.axonframework.lifecycle.Phase;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,14 +39,14 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
-import javax.annotation.PostConstruct;
+import javax.annotation.Nonnull;
 
 /**
  * Axon Cloud implementation of {@link TenantProvider}
  *
  * @author Stefan Dragisic
  */
-public class CloudTenantProvider implements TenantProvider {
+public class CloudTenantProvider implements TenantProvider, Lifecycle {
 
     private static final Logger logger = LoggerFactory.getLogger(CloudTenantProvider.class);
 
@@ -65,7 +67,6 @@ public class CloudTenantProvider implements TenantProvider {
         this.axonServerConnectionManager = axonServerConnectionManager;
     }
 
-    @PostConstruct
     public void start() {
         tenantDescriptors.addAll(getInitialTenants());
         if (preDefinedContexts == null || preDefinedContexts.isEmpty()) {
@@ -92,9 +93,9 @@ public class CloudTenantProvider implements TenantProvider {
 
     private void subscribeToUpdates() {
         //how to subscribe from java to SSE, server sent events (/api/space/{spaceId}/context/updates)
- //      try {
-            //call -> /api/space/{spaceId}/context/updates
-            //get space id from context name, split by @ second part is spaceId
+        //      try {
+        //call -> /api/space/{spaceId}/context/updates
+        //get space id from context name, split by @ second part is spaceId
 //            ResultStream<ContextUpdate> contextUpdatesStream = axonServerConnectionManager
 //                    .getConnection(ADMIN_CTX)
 //                    .adminChannel()
@@ -215,5 +216,10 @@ public class CloudTenantProvider implements TenantProvider {
             registrationMap = new ConcurrentHashMap<>();
             return true;
         };
+    }
+
+    @Override
+    public void registerLifecycleHandlers(@Nonnull Lifecycle.LifecycleRegistry lifecycle) {
+        lifecycle.onStart(Phase.INSTRUCTION_COMPONENTS + 10, this::start);
     }
 }

--- a/multitenancy-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/multitenancy/autoconfig/CloudTenantProvider.java
+++ b/multitenancy-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/multitenancy/autoconfig/CloudTenantProvider.java
@@ -16,13 +16,10 @@
 
 package org.axonframework.extensions.multitenancy.autoconfig;
 
-import io.axoniq.axonserver.grpc.admin.ContextOverview;
-import io.axoniq.axonserver.grpc.admin.ContextUpdate;
 import org.axonframework.axonserver.connector.AxonServerConnectionManager;
 import org.axonframework.common.Registration;
 import org.axonframework.common.StringUtils;
 import org.axonframework.extensions.multitenancy.components.MultiTenantAwareComponent;
-import org.axonframework.extensions.multitenancy.components.TenantConnectPredicate;
 import org.axonframework.extensions.multitenancy.components.TenantDescriptor;
 import org.axonframework.extensions.multitenancy.components.TenantProvider;
 import org.axonframework.lifecycle.Lifecycle;
@@ -54,25 +51,19 @@ public class CloudTenantProvider implements TenantProvider, Lifecycle {
 
     private final Set<TenantDescriptor> tenantDescriptors = new HashSet<>();
     private final String preDefinedContexts;
-    private final TenantConnectPredicate tenantConnectPredicate;
     private final AxonServerConnectionManager axonServerConnectionManager;
     private ConcurrentHashMap<TenantDescriptor, List<Registration>> registrationMap = new ConcurrentHashMap<>();
 
     public CloudTenantProvider(String preDefinedContexts,
-                               TenantConnectPredicate tenantConnectPredicate,
                                //restTemplate
                                AxonServerConnectionManager axonServerConnectionManager) {
         this.preDefinedContexts = preDefinedContexts;
-        this.tenantConnectPredicate = tenantConnectPredicate;
         this.axonServerConnectionManager = axonServerConnectionManager;
     }
 
     public void start() {
         tenantDescriptors.addAll(getInitialTenants());
         tenantDescriptors.forEach(this::addTenant);
-        if (preDefinedContexts == null || preDefinedContexts.isEmpty()) {
-            subscribeToUpdates();
-        }
     }
 
     public List<TenantDescriptor> getInitialTenants() {
@@ -83,8 +74,6 @@ public class CloudTenantProvider implements TenantProvider, Lifecycle {
                                        .map(String::trim)
                                        .map(TenantDescriptor::tenantWithId)
                                        .collect(Collectors.toList());
-            } else {
-                initialTenants = getTenantsAPI();
             }
         } catch (Exception e) {
             logger.error("Error while getting initial tenants", e);
@@ -92,93 +81,9 @@ public class CloudTenantProvider implements TenantProvider, Lifecycle {
         return initialTenants;
     }
 
-    private void subscribeToUpdates() {
-        //how to subscribe from java to SSE, server sent events (/api/space/{spaceId}/context/updates)
-        //      try {
-        //call -> /api/space/{spaceId}/context/updates
-        //get space id from context name, split by @ second part is spaceId
-//            ResultStream<ContextUpdate> contextUpdatesStream = axonServerConnectionManager
-//                    .getConnection(ADMIN_CTX)
-//                    .adminChannel()
-//                    .subscribeToContextUpdates();
-
-
-//            contextUpdatesStream.onAvailable(() -> {
-
-        //     THIS PART IS THE SAME no need to change
-//                try {
-//                    ContextUpdate contextUpdate = contextUpdatesStream.nextIfAvailable();
-//                    if (contextUpdate != null) {
-//                        switch (contextUpdate.getType()) {
-//                            case CREATED:
-//                                handleContextCreated(contextUpdate);
-//                                break;
-//                            case DELETED:
-//                                removeTenant(TenantDescriptor.tenantWithId(contextUpdate.getContext()));
-//                        }
-//                    }
-//                } catch (Exception e) {
-//                    logger.error(e.getMessage(), e);
-//                }
-//            });
-//        } catch (Exception e) {
-//            logger.error("Error while subscribing to context updates", e);
-//        }
-    }
-
-    private void handleContextCreated(ContextUpdate contextUpdate) {
-        try {
-            ContextOverview contextOverview = null; //call /api/space/{spaceId}/context/{id}
-            TenantDescriptor newTenant = toTenantDescriptor(contextOverview);
-            if (tenantConnectPredicate.test(newTenant) && !tenantDescriptors.contains(newTenant)) {
-                addTenant(newTenant);
-            }
-        } catch (Exception e) {
-            logger.error(e.getMessage(), e);
-        }
-    }
-
     @Override
     public List<TenantDescriptor> getTenants() {
         return new ArrayList<>(tenantDescriptors);
-    }
-
-
-    private List<TenantDescriptor> getTenantsAPI() {
-        //call rest endpoint /api/space/{spaceId}/context and return list of TenantDescriptors
-
-        //this you will not need
-//        return axonServerConnectionManager.getConnection(ADMIN_CTX)
-//                                          .adminChannel()
-//                                          .getAllContexts()
-//                                          .join()
-//                                          .stream()
-
-        //this you will need
-//                                          .map(this::toTenantDescriptor)
-//                                          .filter(tenantConnectPredicate)
-//                                          .collect(Collectors.toList());
-        return null;
-    }
-
-    private TenantDescriptor toTenantDescriptor(ContextOverview context) {
-
-        //put to meta data ->
-//        "contextId": "string",
-//                "contextName": "string",
-//                "spaceId": "string",
-//                "type": "string",
-//                "free": true,
-//                "contextStatus": "string",
-//                "region": "string",
-//                "creationTime": "2022-07-15T10:16:37.710Z",
-//                "scheduledCleanupTime": "2022-07-15T10:16:37.710Z",
-//                "clusterId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-//                "contextClusterType": "string"
-
-        return new TenantDescriptor(context.getName(),
-                                    context.getMetaDataMap(), // <---------
-                                    "");
     }
 
     protected void addTenant(TenantDescriptor tenantDescriptor) {
@@ -187,16 +92,6 @@ public class CloudTenantProvider implements TenantProvider, Lifecycle {
                 .forEach(bus -> registrationMap
                         .computeIfAbsent(tenantDescriptor, t -> new CopyOnWriteArrayList<>())
                         .add(bus.registerAndStartTenant(tenantDescriptor)));
-    }
-
-    protected void removeTenant(TenantDescriptor tenantDescriptor) {
-        if (tenantDescriptors.contains(tenantDescriptor) && tenantDescriptors.remove(tenantDescriptor)) {
-            List<Registration> registrations = registrationMap.remove(tenantDescriptor);
-            if (registrations != null && !registrations.isEmpty()) {
-                registrations.forEach(Registration::cancel);
-            }
-            axonServerConnectionManager.disconnect(tenantDescriptor.tenantId());
-        }
     }
 
     @Override

--- a/multitenancy-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/multitenancy/autoconfig/CloudTenantProvider.java
+++ b/multitenancy-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/multitenancy/autoconfig/CloudTenantProvider.java
@@ -69,6 +69,7 @@ public class CloudTenantProvider implements TenantProvider, Lifecycle {
 
     public void start() {
         tenantDescriptors.addAll(getInitialTenants());
+        tenantDescriptors.forEach(this::addTenant);
         if (preDefinedContexts == null || preDefinedContexts.isEmpty()) {
             subscribeToUpdates();
         }

--- a/multitenancy-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/multitenancy/autoconfig/MultiTenancyAxonServerAutoConfiguration.java
+++ b/multitenancy-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/multitenancy/autoconfig/MultiTenancyAxonServerAutoConfiguration.java
@@ -47,6 +47,7 @@ import org.axonframework.queryhandling.SimpleQueryUpdateEmitter;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.spring.config.SpringAxonConfiguration;
 import org.axonframework.springboot.autoconfig.AxonServerAutoConfiguration;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
@@ -71,6 +72,13 @@ import org.springframework.core.env.Environment;
 @ComponentScan(excludeFilters = {
         @ComponentScan.Filter(type = FilterType.REGEX, pattern = "org.axonframework.springboot.autoconfig.AxonServerBusAutoConfiguration.class")})
 public class MultiTenancyAxonServerAutoConfiguration {
+
+    @Autowired
+    public void disableHeartBeat(AxonServerConfiguration axonServerConfiguration, Environment env) {
+        if (!"true".equals(env.getProperty("axon.axonserver.heartbeat.enabled"))) {
+            axonServerConfiguration.getHeartbeat().setEnabled(false);
+        }
+    }
 
     @Bean
     @ConditionalOnClass(name = "org.axonframework.axonserver.connector.command.AxonServerCommandBus")


### PR DESCRIPTION
The first commit is pretty straightforward. It uses a higher number than the `AxonServerConnectionManager` so that that would already be started.

The second commit was needed to have a working setup with Spring Boot 3. There might be a better way to initialize them, but after the fix, I noticed it wasn't working, while the `start()` was called. As the `tenantSegments`  from the `MultiTenantQueryBus` were still empty, this makes sure all the initial tenants are added.

This will fix https://github.com/AxonFramework/extension-multitenancy/issues/93.