### PR TITLE
Remove replication group field

### DIFF
--- a/multitenancy-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/multitenancy/autoconfig/AxonServerTenantProvider.java
+++ b/multitenancy-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/multitenancy/autoconfig/AxonServerTenantProvider.java
@@ -35,6 +35,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -155,9 +156,10 @@ public class AxonServerTenantProvider implements TenantProvider, Lifecycle {
     }
 
     private TenantDescriptor toTenantDescriptor(ContextOverview context) {
-        return new TenantDescriptor(context.getName(),
-                                    context.getMetaDataMap(),
-                                    context.getReplicationGroup().getName());
+        Map<String, String> metaDataMap = context.getMetaDataMap();
+        metaDataMap.putIfAbsent("replicationGroup", context.getReplicationGroup().getName());
+
+        return new TenantDescriptor(context.getName(), metaDataMap);
     }
 
     protected void addTenant(TenantDescriptor tenantDescriptor) {

--- a/multitenancy-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/multitenancy/autoconfig/AxonServerTenantProvider.java
+++ b/multitenancy-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/multitenancy/autoconfig/AxonServerTenantProvider.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -156,7 +157,7 @@ public class AxonServerTenantProvider implements TenantProvider, Lifecycle {
     }
 
     private TenantDescriptor toTenantDescriptor(ContextOverview context) {
-        Map<String, String> metaDataMap = context.getMetaDataMap();
+        Map<String, String> metaDataMap = new HashMap<>(context.getMetaDataMap());
         metaDataMap.putIfAbsent("replicationGroup", context.getReplicationGroup().getName());
 
         return new TenantDescriptor(context.getName(), metaDataMap);

--- a/multitenancy-spring-boot-autoconfigure/src/test/java/org/axonframework/extensions/multitenancy/autoconfig/AxonServerTenantProviderTest.java
+++ b/multitenancy-spring-boot-autoconfigure/src/test/java/org/axonframework/extensions/multitenancy/autoconfig/AxonServerTenantProviderTest.java
@@ -161,9 +161,16 @@ class AxonServerTenantProviderTest {
 
         Thread.sleep(3000);
 
+        ArgumentCaptor<TenantDescriptor> tenantDescriptorArgumentCaptor = ArgumentCaptor.forClass(TenantDescriptor.class);
+
         //initial setup
-        verify(mockComponent).registerTenant(TenantDescriptor.tenantWithId("tenant-3"));
-        verify(mockComponent).registerTenant(TenantDescriptor.tenantWithId("tenant-4"));
+        verify(mockComponent).registerAndStartTenant(tenantDescriptorArgumentCaptor.capture());
+        assertEquals("tenant-3", tenantDescriptorArgumentCaptor.getValue().tenantId());
+        assertEquals("tenant-3-rp", tenantDescriptorArgumentCaptor.getValue().properties().get("replicationGroup"));
+
+        verify(mockComponent).registerAndStartTenant(tenantDescriptorArgumentCaptor.capture());
+        assertEquals("tenant-4", tenantDescriptorArgumentCaptor.getValue().tenantId());
+        assertEquals("tenant-4-rp", tenantDescriptorArgumentCaptor.getValue().properties().get("replicationGroup"));
 
         //additionally created contexts
         verify(mockComponent).registerAndStartTenant(TenantDescriptor.tenantWithId("tenant-1"));

--- a/multitenancy-spring-boot-autoconfigure/src/test/java/org/axonframework/extensions/multitenancy/autoconfig/AxonServerTenantProviderTest.java
+++ b/multitenancy-spring-boot-autoconfigure/src/test/java/org/axonframework/extensions/multitenancy/autoconfig/AxonServerTenantProviderTest.java
@@ -164,13 +164,20 @@ class AxonServerTenantProviderTest {
         ArgumentCaptor<TenantDescriptor> tenantDescriptorArgumentCaptor = ArgumentCaptor.forClass(TenantDescriptor.class);
 
         //initial setup
-        verify(mockComponent).registerAndStartTenant(tenantDescriptorArgumentCaptor.capture());
-        assertEquals("tenant-3", tenantDescriptorArgumentCaptor.getValue().tenantId());
-        assertEquals("tenant-3-rp", tenantDescriptorArgumentCaptor.getValue().properties().get("replicationGroup"));
+        verify(mockComponent, times(2)).registerTenant(tenantDescriptorArgumentCaptor.capture());
 
-        verify(mockComponent).registerAndStartTenant(tenantDescriptorArgumentCaptor.capture());
-        assertEquals("tenant-4", tenantDescriptorArgumentCaptor.getValue().tenantId());
-        assertEquals("tenant-4-rp", tenantDescriptorArgumentCaptor.getValue().properties().get("replicationGroup"));
+        tenantDescriptorArgumentCaptor.getAllValues().forEach(tenantDescriptor -> {
+            if (tenantDescriptor.tenantId().equals("tenant-3")) {
+                assertEquals("tenant-3", tenantDescriptor.tenantId());
+                assertEquals("tenant-3-rp", tenantDescriptor.properties().get("replicationGroup"));
+            } else if (tenantDescriptor.tenantId().equals("tenant-4")) {
+                assertEquals("tenant-4", tenantDescriptor.tenantId());
+                assertEquals("tenant-4-rp", tenantDescriptor.properties().get("replicationGroup"));
+            } else {
+                fail("Unexpected tenant descriptor");
+            }
+        });
+
 
         //additionally created contexts
         verify(mockComponent).registerAndStartTenant(TenantDescriptor.tenantWithId("tenant-1"));

--- a/multitenancy/src/main/java/org/axonframework/extensions/multitenancy/components/TenantDescriptor.java
+++ b/multitenancy/src/main/java/org/axonframework/extensions/multitenancy/components/TenantDescriptor.java
@@ -31,16 +31,13 @@ public class TenantDescriptor {
 
     protected Map<String, String> properties;
 
-    protected String replicationGroup;
-
     public TenantDescriptor(String tenantId) {
         this.tenantId = tenantId;
     }
 
-    public TenantDescriptor(String tenantId, Map<String, String> properties, String replicationGroup) {
+    public TenantDescriptor(String tenantId, Map<String, String> properties) {
         this.tenantId = tenantId;
         this.properties = properties;
-        this.replicationGroup = replicationGroup;
     }
 
     /**
@@ -60,15 +57,6 @@ public class TenantDescriptor {
      */
     public Map<String, String> properties() {
         return properties;
-    }
-
-    /**
-     * The replication group of the tenant. Directly mapped to the context replication group.
-     *
-     * @return
-     */
-    public String replicationGroup() {
-        return replicationGroup;
     }
 
     @Override


### PR DESCRIPTION
Since the extension should offer a flexible API for both Axon Server and non-Axon Server users, the replication group field *should not* be part of `TenantDescriptor`. 
Hence, this pull request moves it to the `MetaData` instead.

Note this is a breaking change. However, the chance is extremely slim that anybody was using it, hence it's removed regardless.

By making this adjustment, this PR resolves #99.