### PR TITLE
Define custom tenant source

### DIFF
--- a/multitenancy-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/multitenancy/autoconfig/MultiTenancyAutoConfiguration.java
+++ b/multitenancy-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/multitenancy/autoconfig/MultiTenancyAutoConfiguration.java
@@ -111,7 +111,7 @@ public class MultiTenancyAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public MultiTenantStreamableMessageSourceProvider multiTenantStreamableMessageSourceConfiguration() {
+    public MultiTenantStreamableMessageSourceProvider multiTenantStreamableMessageSourceProvider() {
         return (defaultTenantSource, processorName, tenantDescriptor, configuration) -> defaultTenantSource;
     }
 

--- a/multitenancy-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/multitenancy/autoconfig/MultiTenancyAutoConfiguration.java
+++ b/multitenancy-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/multitenancy/autoconfig/MultiTenancyAutoConfiguration.java
@@ -27,7 +27,7 @@ import org.axonframework.extensions.multitenancy.components.eventstore.TenantEve
 import org.axonframework.extensions.multitenancy.components.queryhandeling.MultiTenantQueryBus;
 import org.axonframework.extensions.multitenancy.components.queryhandeling.TenantQuerySegmentFactory;
 import org.axonframework.extensions.multitenancy.configuration.MultiTenantEventProcessingModule;
-import org.axonframework.extensions.multitenancy.configuration.MultiTenantStreamableMessageSourceConfiguration;
+import org.axonframework.extensions.multitenancy.configuration.MultiTenantStreamableMessageSourceProvider;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.correlation.CorrelationDataProvider;
 import org.axonframework.springboot.util.ConditionalOnMissingQualifiedBean;
@@ -111,14 +111,14 @@ public class MultiTenancyAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public MultiTenantStreamableMessageSourceConfiguration multiTenantStreamableMessageSourceConfiguration() {
+    public MultiTenantStreamableMessageSourceProvider multiTenantStreamableMessageSourceConfiguration() {
         return (defaultTenantSource, processorName, tenantDescriptor, configuration) -> defaultTenantSource;
     }
 
     @Bean
     public MultiTenantEventProcessingModule multiTenantEventProcessingModule(TenantProvider tenantProvider,
-                                                                             MultiTenantStreamableMessageSourceConfiguration multiTenantStreamableMessageSourceConfiguration) {
-        return new MultiTenantEventProcessingModule(tenantProvider, multiTenantStreamableMessageSourceConfiguration);
+                                                                             MultiTenantStreamableMessageSourceProvider multiTenantStreamableMessageSourceProvider) {
+        return new MultiTenantEventProcessingModule(tenantProvider, multiTenantStreamableMessageSourceProvider);
     }
 
     @Bean

--- a/multitenancy-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/multitenancy/autoconfig/MultiTenancyAutoConfiguration.java
+++ b/multitenancy-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/multitenancy/autoconfig/MultiTenancyAutoConfiguration.java
@@ -27,6 +27,7 @@ import org.axonframework.extensions.multitenancy.components.eventstore.TenantEve
 import org.axonframework.extensions.multitenancy.components.queryhandeling.MultiTenantQueryBus;
 import org.axonframework.extensions.multitenancy.components.queryhandeling.TenantQuerySegmentFactory;
 import org.axonframework.extensions.multitenancy.configuration.MultiTenantEventProcessingModule;
+import org.axonframework.extensions.multitenancy.configuration.MultiTenantStreamableMessageSourceConfiguration;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.correlation.CorrelationDataProvider;
 import org.axonframework.springboot.util.ConditionalOnMissingQualifiedBean;
@@ -107,9 +108,17 @@ public class MultiTenancyAutoConfiguration {
         return multiTenantEventStore;
     }
 
+
     @Bean
-    public MultiTenantEventProcessingModule multiTenantEventProcessingModule(TenantProvider tenantProvider) {
-        return new MultiTenantEventProcessingModule(tenantProvider);
+    @ConditionalOnMissingBean
+    public MultiTenantStreamableMessageSourceConfiguration multiTenantStreamableMessageSourceConfiguration() {
+        return (defaultTenantSource, processorName, tenantDescriptor, configuration) -> defaultTenantSource;
+    }
+
+    @Bean
+    public MultiTenantEventProcessingModule multiTenantEventProcessingModule(TenantProvider tenantProvider,
+                                                                             MultiTenantStreamableMessageSourceConfiguration multiTenantStreamableMessageSourceConfiguration) {
+        return new MultiTenantEventProcessingModule(tenantProvider, multiTenantStreamableMessageSourceConfiguration);
     }
 
     @Bean

--- a/multitenancy/src/main/java/org/axonframework/extensions/multitenancy/configuration/MultiTenantEventProcessingModule.java
+++ b/multitenancy/src/main/java/org/axonframework/extensions/multitenancy/configuration/MultiTenantEventProcessingModule.java
@@ -55,6 +55,7 @@ public class MultiTenantEventProcessingModule extends EventProcessingModule {
     /**
      * Initializes a {@link MultiTenantEventProcessingModule} with a default {@link TenantProvider} and a default {@link MultiTenantStreamableMessageSourceProvider},
      * which does not change the default {@link StreamableMessageSource} for any {@link TenantDescriptor}.
+     *
      * @param tenantProvider the default {@link TenantProvider} used to build {@link MultiTenantEventProcessor}s
      */
     public MultiTenantEventProcessingModule(TenantProvider tenantProvider) {
@@ -65,8 +66,9 @@ public class MultiTenantEventProcessingModule extends EventProcessingModule {
     /**
      *  Initializes a {@link MultiTenantEventProcessingModule} with a default {@link TenantProvider} and a {@link MultiTenantStreamableMessageSourceProvider},
      *  which allows for the customization of the {@link StreamableMessageSource} for each {@link TenantDescriptor}.
+     *
      * @param tenantProvider the default {@link TenantProvider} used to build {@link MultiTenantEventProcessor}s
-     * @param multiTenantStreamableMessageSourceProvider the {@link MultiTenantStreamableMessageSourceProvider}used to customize the {@link StreamableMessageSource} for each {@link TenantDescriptor}
+     * @param multiTenantStreamableMessageSourceProvider the {@link MultiTenantStreamableMessageSourceProvider} used to customize the {@link StreamableMessageSource} for each {@link TenantDescriptor}
      */
     public MultiTenantEventProcessingModule(TenantProvider tenantProvider,
                                             MultiTenantStreamableMessageSourceProvider multiTenantStreamableMessageSourceProvider) {

--- a/multitenancy/src/main/java/org/axonframework/extensions/multitenancy/configuration/MultiTenantStreamableMessageSourceConfiguration.java
+++ b/multitenancy/src/main/java/org/axonframework/extensions/multitenancy/configuration/MultiTenantStreamableMessageSourceConfiguration.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extensions.multitenancy.configuration;
+
+import org.axonframework.config.Configuration;
+import org.axonframework.eventhandling.TrackedEventMessage;
+import org.axonframework.extensions.multitenancy.components.TenantDescriptor;
+import org.axonframework.messaging.StreamableMessageSource;
+
+
+/**
+ * A functional interface for building a {@link StreamableMessageSource} for a given {@link TenantDescriptor} and processor name.
+ * @author Stefan Dragisic
+ */
+@FunctionalInterface
+public interface  MultiTenantStreamableMessageSourceConfiguration {
+     StreamableMessageSource<TrackedEventMessage<?>> build(
+             StreamableMessageSource<TrackedEventMessage<?>> defaultTenantSource,
+             String processorName,
+             TenantDescriptor tenantDescriptor,
+             Configuration configuration);
+
+}

--- a/multitenancy/src/main/java/org/axonframework/extensions/multitenancy/configuration/MultiTenantStreamableMessageSourceProvider.java
+++ b/multitenancy/src/main/java/org/axonframework/extensions/multitenancy/configuration/MultiTenantStreamableMessageSourceProvider.java
@@ -25,9 +25,17 @@ import org.axonframework.messaging.StreamableMessageSource;
 /**
  * A functional interface for building a {@link StreamableMessageSource} for a given {@link TenantDescriptor} and processor name.
  * @author Stefan Dragisic
+ * @since 4.8.0
  */
 @FunctionalInterface
-public interface  MultiTenantStreamableMessageSourceConfiguration {
+public interface MultiTenantStreamableMessageSourceProvider {
+     /**
+        * Builds a custom {@link StreamableMessageSource} for a given {@link TenantDescriptor} and processor name.
+        * @param defaultTenantSource the default {@link StreamableMessageSource} to be used if no tenant specific source is configured
+        * @param processorName the name of the processor for which the {@link StreamableMessageSource} is built
+        * @param tenantDescriptor the {@link TenantDescriptor} for which the {@link StreamableMessageSource} is built
+        * @param configuration the {@link Configuration} used to build the {@link StreamableMessageSource}
+      */
      StreamableMessageSource<TrackedEventMessage<?>> build(
              StreamableMessageSource<TrackedEventMessage<?>> defaultTenantSource,
              String processorName,

--- a/multitenancy/src/main/java/org/axonframework/extensions/multitenancy/configuration/MultiTenantStreamableMessageSourceProvider.java
+++ b/multitenancy/src/main/java/org/axonframework/extensions/multitenancy/configuration/MultiTenantStreamableMessageSourceProvider.java
@@ -23,15 +23,18 @@ import org.axonframework.messaging.StreamableMessageSource;
 
 
 /**
- * A functional interface for building a {@link StreamableMessageSource} for a given {@link TenantDescriptor} and processor name.
+ * A functional interface to provide a {@link StreamableMessageSource} for a given {@link TenantDescriptor} and processor name.
+ *
  * @author Stefan Dragisic
  * @since 4.8.0
  */
 @FunctionalInterface
 public interface MultiTenantStreamableMessageSourceProvider {
+     
      /**
-        * Builds a custom {@link StreamableMessageSource} for a given {@link TenantDescriptor} and processor name.
-        * @param defaultTenantSource the default {@link StreamableMessageSource} to be used if no tenant specific source is configured
+        * Provide a custom {@link StreamableMessageSource} for a given {@link TenantDescriptor} and processor name.
+        *
+        * @param defaultTenantSource the default {@link StreamableMessageSource} to be used if no tenant-specific source is configured
         * @param processorName the name of the processor for which the {@link StreamableMessageSource} is built
         * @param tenantDescriptor the {@link TenantDescriptor} for which the {@link StreamableMessageSource} is built
         * @param configuration the {@link Configuration} used to build the {@link StreamableMessageSource}

--- a/multitenancy/src/test/java/org/axonframework/extensions/multitenancy/configuration/MultiTenantEventProcessingModuleTest.java
+++ b/multitenancy/src/test/java/org/axonframework/extensions/multitenancy/configuration/MultiTenantEventProcessingModuleTest.java
@@ -52,13 +52,13 @@ class MultiTenantEventProcessingModuleTest {
     private Configurer configurer;
     private MultiTenantEventProcessor multiTenantEventProcessor;
 
-    private MultiTenantStreamableMessageSourceConfiguration multiTenantStreamableMessageSourceConfiguration;
+    private MultiTenantStreamableMessageSourceProvider multiTenantStreamableMessageSourceProvider;
 
     @BeforeEach
     void setUp() {
         configurer = DefaultConfigurer.defaultConfiguration();
         multiTenantEventProcessor = mock(MultiTenantEventProcessor.class);
-        multiTenantStreamableMessageSourceConfiguration =
+        multiTenantStreamableMessageSourceProvider =
                 (defaultSource, processorName, tenantDescriptor, configuration) -> defaultSource;
     }
 
@@ -137,10 +137,11 @@ class MultiTenantEventProcessingModuleTest {
         StreamableMessageSource<TrackedEventMessage<?>> customSource = mock(StreamableMessageSource.class);
         TenantProvider tenantProvider = mock(TenantProvider.class);
 
-        MultiTenantStreamableMessageSourceConfiguration multiTenantStreamableMessageSourceConfiguration =
+        MultiTenantStreamableMessageSourceProvider multiTenantStreamableMessageSourceProvider =
                 (source, processorName, tenantDescriptor, configuration) -> customSource;
 
-        configurer.registerModule(new MultiTenantEventProcessingModule(tenantProvider,multiTenantStreamableMessageSourceConfiguration));
+        configurer.registerModule(new MultiTenantEventProcessingModule(tenantProvider,
+                                                                       multiTenantStreamableMessageSourceProvider));
         TrackingEventProcessorConfiguration testTepConfig =
                 TrackingEventProcessorConfiguration.forParallelProcessing(4);
         configurer.eventProcessing()
@@ -265,12 +266,12 @@ class MultiTenantEventProcessingModuleTest {
 
         StreamableMessageSource<TrackedEventMessage<?>> customSource = mock(StreamableMessageSource.class);
 
-        MultiTenantStreamableMessageSourceConfiguration multiTenantStreamableMessageSourceConfiguration =
+        MultiTenantStreamableMessageSourceProvider multiTenantStreamableMessageSourceProvider =
                 (source, processorName, tenantDescriptor, configuration) -> customSource;
 
         TenantProvider tenantProvider = mock(TenantProvider.class);
         configurer.registerModule(new MultiTenantEventProcessingModule(tenantProvider,
-                                                                       multiTenantStreamableMessageSourceConfiguration));
+                                                                       multiTenantStreamableMessageSourceProvider));
         TrackingEventProcessorConfiguration testTepConfig =
                 TrackingEventProcessorConfiguration.forParallelProcessing(4);
         configurer.eventProcessing()

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
             ${project.basedir}/../coverage-report/target/site/jacoco-aggregate/jacoco.xml
         </sonar.coverage.jacoco.xmlReportPaths>
 
-        <axon.version>4.7.0</axon.version>
+        <axon.version>4.8.0-SNAPSHOT</axon.version>
 
         <projectreactor.version>3.5.5</projectreactor.version>
 


### PR DESCRIPTION
Allow users to override default tenant message source, by replacing it or combining it with other source.
Solves #103 