### PR TITLE
Drop `properties` validation in `TenantDescriptor#equals`

### DIFF
--- a/multitenancy/src/main/java/org/axonframework/extensions/multitenancy/components/TenantDescriptor.java
+++ b/multitenancy/src/main/java/org/axonframework/extensions/multitenancy/components/TenantDescriptor.java
@@ -87,7 +87,7 @@ public class TenantDescriptor {
             return false;
         }
         TenantDescriptor that = (TenantDescriptor) o;
-        return Objects.equals(tenantId, that.tenantId) && Objects.equals(properties, that.properties);
+        return Objects.equals(tenantId, that.tenantId);
     }
 
     @Override

--- a/multitenancy/src/main/java/org/axonframework/extensions/multitenancy/components/TenantDescriptor.java
+++ b/multitenancy/src/main/java/org/axonframework/extensions/multitenancy/components/TenantDescriptor.java
@@ -92,7 +92,7 @@ public class TenantDescriptor {
 
     @Override
     public int hashCode() {
-        return Objects.hash(tenantId, properties);
+        return Objects.hash(tenantId);
     }
 
     @Override

--- a/multitenancy/src/test/java/org/axonframework/extensions/multitenancy/components/TenantDescriptorTest.java
+++ b/multitenancy/src/test/java/org/axonframework/extensions/multitenancy/components/TenantDescriptorTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extensions.multitenancy.components;
+
+import org.junit.jupiter.api.*;
+
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test class validating the {@link TenantDescriptor}.
+ *
+ * @author Steven van Beelen
+ */
+class TenantDescriptorTest {
+
+    private static final String TENANT_ID_ONE = "me";
+    private static final String TENANT_ID_TWO = "you";
+
+    @Test
+    void equalsOnlyValidatesTenantId() {
+        HashMap<String, String> testPropertiesOne = new HashMap<>();
+        testPropertiesOne.put("key", "value");
+        testPropertiesOne.put("key1", "value2");
+        HashMap<String, String> testPropertiesTwo = new HashMap<>();
+        testPropertiesOne.put("value", "key");
+        testPropertiesOne.put("value2", "key1");
+
+        TenantDescriptor testSubjectOne = TenantDescriptor.tenantWithId(TENANT_ID_ONE);
+        TenantDescriptor testSubjectTwo = TenantDescriptor.tenantWithId(TENANT_ID_TWO);
+        TenantDescriptor testSubjectThree = new TenantDescriptor(TENANT_ID_ONE, testPropertiesOne);
+        TenantDescriptor testSubjectFour = new TenantDescriptor(TENANT_ID_TWO, testPropertiesTwo);
+        TenantDescriptor testSubjectFive = new TenantDescriptor(TENANT_ID_ONE, testPropertiesTwo);
+
+        // Validate test subject one, only matching on tenant id
+        assertNotEquals(testSubjectOne, testSubjectTwo);
+        assertEquals(testSubjectOne, testSubjectThree);
+        assertNotEquals(testSubjectOne, testSubjectFour);
+        assertEquals(testSubjectOne, testSubjectFive);
+        // Validate test subject two, only matching on tenant id
+        assertNotEquals(testSubjectTwo, testSubjectThree);
+        assertEquals(testSubjectTwo, testSubjectFour);
+        assertNotEquals(testSubjectTwo, testSubjectFive);
+        // Validate test subject three, only matching on tenant id
+        assertNotEquals(testSubjectThree, testSubjectFour);
+        assertEquals(testSubjectThree, testSubjectFive);
+        // Validate test subject four, only matching on tenant id
+        assertNotEquals(testSubjectFour, testSubjectFive);
+    }
+}

--- a/multitenancy/src/test/java/org/axonframework/extensions/multitenancy/components/TenantDescriptorTest.java
+++ b/multitenancy/src/test/java/org/axonframework/extensions/multitenancy/components/TenantDescriptorTest.java
@@ -32,21 +32,27 @@ class TenantDescriptorTest {
     private static final String TENANT_ID_ONE = "me";
     private static final String TENANT_ID_TWO = "you";
 
-    @Test
-    void equalsOnlyValidatesTenantId() {
-        HashMap<String, String> testPropertiesOne = new HashMap<>();
+    private HashMap<String, String> testPropertiesOne;
+    private HashMap<String, String> testPropertiesTwo;
+
+    private final TenantDescriptor testSubjectOne = TenantDescriptor.tenantWithId(TENANT_ID_ONE);
+    private final TenantDescriptor testSubjectTwo = TenantDescriptor.tenantWithId(TENANT_ID_TWO);
+    private final TenantDescriptor testSubjectThree = new TenantDescriptor(TENANT_ID_ONE, testPropertiesOne);
+    private final TenantDescriptor testSubjectFour = new TenantDescriptor(TENANT_ID_TWO, testPropertiesTwo);
+    private final TenantDescriptor testSubjectFive = new TenantDescriptor(TENANT_ID_ONE, testPropertiesTwo);
+
+    @BeforeEach
+    void setUp() {
+        testPropertiesOne = new HashMap<>();
         testPropertiesOne.put("key", "value");
         testPropertiesOne.put("key1", "value2");
-        HashMap<String, String> testPropertiesTwo = new HashMap<>();
+        testPropertiesTwo = new HashMap<>();
         testPropertiesOne.put("value", "key");
         testPropertiesOne.put("value2", "key1");
+    }
 
-        TenantDescriptor testSubjectOne = TenantDescriptor.tenantWithId(TENANT_ID_ONE);
-        TenantDescriptor testSubjectTwo = TenantDescriptor.tenantWithId(TENANT_ID_TWO);
-        TenantDescriptor testSubjectThree = new TenantDescriptor(TENANT_ID_ONE, testPropertiesOne);
-        TenantDescriptor testSubjectFour = new TenantDescriptor(TENANT_ID_TWO, testPropertiesTwo);
-        TenantDescriptor testSubjectFive = new TenantDescriptor(TENANT_ID_ONE, testPropertiesTwo);
-
+    @Test
+    void equalsOnlyValidatesTenantId() {
         // Validate test subject one, only matching on tenant id
         assertNotEquals(testSubjectOne, testSubjectTwo);
         assertEquals(testSubjectOne, testSubjectThree);
@@ -61,5 +67,23 @@ class TenantDescriptorTest {
         assertEquals(testSubjectThree, testSubjectFive);
         // Validate test subject four, only matching on tenant id
         assertNotEquals(testSubjectFour, testSubjectFive);
+    }
+
+    @Test
+    void hashOnlyHashesTenantId() {
+        // Validate test subject one, only matching on tenant id
+        assertNotEquals(testSubjectOne.hashCode(), testSubjectTwo.hashCode());
+        assertEquals(testSubjectOne.hashCode(), testSubjectThree.hashCode());
+        assertNotEquals(testSubjectOne.hashCode(), testSubjectFour.hashCode());
+        assertEquals(testSubjectOne.hashCode(), testSubjectFive.hashCode());
+        // Validate test subject two, only matching on tenant id
+        assertNotEquals(testSubjectTwo.hashCode(), testSubjectThree.hashCode());
+        assertEquals(testSubjectTwo.hashCode(), testSubjectFour.hashCode());
+        assertNotEquals(testSubjectTwo.hashCode(), testSubjectFive.hashCode());
+        // Validate test subject three, only matching on tenant id
+        assertNotEquals(testSubjectThree.hashCode(), testSubjectFour.hashCode());
+        assertEquals(testSubjectThree.hashCode(), testSubjectFive.hashCode());
+        // Validate test subject four, only matching on tenant id
+        assertNotEquals(testSubjectFour.hashCode(), testSubjectFive.hashCode());
     }
 }


### PR DESCRIPTION
During a clean-up of this repository I (yes, me) accidentally introduces the `propeties` to the `TenantDescriptor#equals` method.
This was, as it turns out, wrong.

The `TenantDescriptor` is both constructed by the extension it self and by users, both not necessarily knowledgable about the properties, but definitely knowledgable about the right `tenantId`.
To have the multi-tenancy extension behave as intended, validating the `TenantDescriptor` based on **just** it's `tenantId` is paramount.

As such, this pull request removes `properties` from the `TenantDescriptor#equals` method again.
Furthermore, I have added a test case to validate the `properties` field does not have any influence on the behavior of `equals`.