### PR TITLE
Allow existence of non-tenant processors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,30 +1,42 @@
 version: 2
+
 updates:
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
+    day: "sunday"
   open-pull-requests-limit: 5
   labels:
     - "Type: Dependency Upgrade"
     - "Priority 1: Must"
-  reviewers:
-    - "CodeDrivenMitch"
-    - "gklijs"
-    - "schananas"
-    - "smcvb"
   milestone: 10
+  reviewers:
+    - "AxonFramework/framework-developers"
+    - "schananas"
+  groups:
+    github-dependencies:
+      update-types:
+        - "patch"
+        - "minor"
+        - "major"
+
 - package-ecosystem: maven
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
+    day: "sunday"
   open-pull-requests-limit: 5
   labels:
     - "Type: Dependency Upgrade"
     - "Priority 1: Must"
-  reviewers:
-    - "CodeDrivenMitch"
-    - "gklijs"
-    - "schananas"
-    - "smcvb"
   milestone: 10
+  reviewers:
+    - "AxonFramework/framework-developers"
+    - "schananas"
+  groups:
+    maven-dependencies:
+      update-types:
+        - "patch"
+        - "minor"
+        - "major"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
     - "gklijs"
     - "schananas"
     - "smcvb"
-  milestone: 8
+  milestone: 9
 - package-ecosystem: maven
   directory: "/"
   schedule:
@@ -27,4 +27,4 @@ updates:
     - "gklijs"
     - "schananas"
     - "smcvb"
-  milestone: 8
+  milestone: 9

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ public class EventSchedulingComponent {
 
 #### Overriding default message source
 
-You can override default message source for each tenant by defining following bean:
+You can override the default message source for each tenant by defining the following bean:
 
 ```
     @Bean

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Note that this works by using JPA multi-tenancy support, that means only SQL Dat
 If you wish to implement multi-tenancy for a different type of databases (e.g. NoSQL) make sure that your projection database supports multi-tenancy.
 While in transaction you may find out which tenant owns transaction by calling:` TenantWrappedTransactionManager.getCurrentTenant()`.
 
-For more hints how to enable multi-tenancy for NoSQL databases check on how JPA SQL version is [implemented](MultiTenantDataSourceManager.java)
+For more hints how to enable multi-tenancy for NoSQL databases check on how JPA SQL version is [implemented](https://github.com/AxonFramework/extension-multitenancy/blob/main/multitenancy-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/multitenancy/autoconfig/MultiTenantDataSourceManager.java)
 
 Important: In this case Liquibase or Flyway will not be able to initialise schemas for dynamic data sources. Any datasource that you use needs to have pre-initialized schema.
 
@@ -177,8 +177,6 @@ Not supported components are:
 
 - <span style="color:red">Deadline Manager</span>
 
-
-
 ### Disable extension
 
 By default, extension is automatically enabled.
@@ -186,14 +184,13 @@ If you wish to disable extension without removing extension use following proper
 
 `axon.multi-tenancy.enabled=false`
 
-
 ## Receiving help
 
 Are you having trouble using the extension?
 We'd like to help you out the best we can!
 There are a couple of things to consider when you're traversing anything Axon:
 
-* Checking the [reference guide](https://docs.axoniq.io/reference-guide/extensions/multitenancy) should be your first stop,
+* Checking the [reference guide](https://docs.axoniq.io/reference-guide/) should be your first stop,
   as the majority of possible scenarios you might encounter when using Axon should be covered there.
 * If the Reference Guide does not cover a specific topic you would've expected,
   we'd appreciate if you could file an [issue](https://github.com/AxonIQ/reference-guide/issues) about it for us.

--- a/README.md
+++ b/README.md
@@ -255,7 +255,8 @@ This bean should return a `StreamableMessageSource` that will be used for specif
 
 #### Disable multi-tenancy for specific Event Processor
 
-In certain cases, you may want to disable multi-tenancy for specific Event Processor which does not have any tenants, such as when you have event processor that is consuming events from external context.
+In certain cases, you may want to disable multi-tenancy for specific Event Processor which does not have any tenants.
+For example, when you have an event processor that is consuming events from an external context.
 Per default, each event processor is scaled, and duplicated for each tenant. To disable this behavior for a specific processing, you can define following bean:
 
 ```

--- a/README.md
+++ b/README.md
@@ -232,6 +232,42 @@ public class EventSchedulingComponent {
 }
 ```
 
+### Advanced configuration
+
+#### Overriding default message source
+
+You can override default message source for each tenant by defining following bean:
+
+```
+    @Bean
+    public MultiTenantStreamableMessageSourceProvider multiTenantStreamableMessageSourceProvider(AxonServerEventStore customSource) {
+        return (defaultTenantSource, processorName, tenantDescriptor, configuration) -> {
+            if (tenantDescriptor.tenantId().startsWith("tenant-custom")) {
+                return customSource;
+            }
+            return defaultTenantSource;
+
+        };
+    }
+```
+
+Bean should return `StreamableMessageSource` that will be used for specific tenant. This lambda will be called for each tenant and each event processor, so be sure to return a default tenant source if you don't want to override it.
+
+#### Disable multi-tenancy for specific Event Processor
+
+In certain cases, you may want to disable multi-tenancy for specific Event Processor which does not have any tenants, such as when you have event processor that is consuming events from external context.
+Per default, each event processor is scaled, and duplicated for each tenant. To disable this behavior for a specific processing, you can define following bean:
+
+```
+    @Bean
+    public MultiTenantEventProcessorPredicate multiTenantEventProcessorPredicate() {
+        return (processorName) -> !processorName.equals("external-context");
+    }
+```
+
+This bean should return `true` for each processor that you want to be multi-tenant, and `false` for each processor that you want to be single tenant.
+
+
 ### Supported multi-tenant components
 
 Currently, supported multi-tenants components are as follows:

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ You can override the default message source for each tenant by defining the foll
     }
 ```
 
-Bean should return `StreamableMessageSource` that will be used for specific tenant. This lambda will be called for each tenant and each event processor, so be sure to return a default tenant source if you don't want to override it.
+This bean should return a `StreamableMessageSource` that will be used for specific tenants. This lambda will be called for each tenant and each event processor, so be sure to return a default tenant source if you don't want to override it.
 
 #### Disable multi-tenancy for specific Event Processor
 

--- a/coverage-report/pom.xml
+++ b/coverage-report/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>axon-multitenancy-parent</artifactId>
         <groupId>org.axonframework.extensions.multitenancy</groupId>
-        <version>4.9.0-SNAPSHOT</version>
+        <version>4.9.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>axon-coverage-report</artifactId>

--- a/multitenancy-spring-boot-3-integrationtests/pom.xml
+++ b/multitenancy-spring-boot-3-integrationtests/pom.xml
@@ -33,7 +33,7 @@
     <description>
         Module used to test the integration with Spring Boot 3
     </description>
-    <version>4.9.0-SNAPSHOT</version>
+    <version>4.9.1-SNAPSHOT</version>
 
     <packaging>jar</packaging>
 

--- a/multitenancy-spring-boot-3-integrationtests/pom.xml
+++ b/multitenancy-spring-boot-3-integrationtests/pom.xml
@@ -38,7 +38,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <axon.version>4.9.0-SNAPSHOT</axon.version>
+        <axon.version>4.9.1-SNAPSHOT</axon.version>
         <testcoontainers.version>1.19.3</testcoontainers.version>
 
         <jar-plugin.version>3.3.0</jar-plugin.version>

--- a/multitenancy-spring-boot-3-integrationtests/src/test/java/org/axonframework/extensions/multitenancy/integration/MultiTenancyIntegrationTest.java
+++ b/multitenancy-spring-boot-3-integrationtests/src/test/java/org/axonframework/extensions/multitenancy/integration/MultiTenancyIntegrationTest.java
@@ -67,6 +67,7 @@ class MultiTenancyIntegrationTest {
     @BeforeEach
     void setUp() {
         testApplicationContext = new ApplicationContextRunner()
+                .withSystemProperties("disable-axoniq-console-message=true")
                 .withPropertyValues("axon.axonserver.enabled=true")
                 .withPropertyValues("axon.axonserver.servers=" + AXON_SERVER_CONTAINER.getAxonServerAddress())
                 .withUserConfiguration(DefaultContext.class);

--- a/multitenancy-spring-boot-3-integrationtests/src/test/java/org/axonframework/extensions/multitenancy/integration/MultiTenancyIntegrationTest.java
+++ b/multitenancy-spring-boot-3-integrationtests/src/test/java/org/axonframework/extensions/multitenancy/integration/MultiTenancyIntegrationTest.java
@@ -62,8 +62,7 @@ class MultiTenancyIntegrationTest {
     private ApplicationContextRunner testApplicationContext;
 
     @Container
-    private static final AxonServerContainer AXON_SERVER_CONTAINER =
-            new AxonServerContainer("axoniq/axonserver:latest-dev");
+    private static final AxonServerContainer AXON_SERVER_CONTAINER = new AxonServerContainer();
 
     @BeforeEach
     void setUp() {

--- a/multitenancy-spring-boot-autoconfigure/pom.xml
+++ b/multitenancy-spring-boot-autoconfigure/pom.xml
@@ -14,13 +14,12 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>axon-multitenancy-parent</artifactId>
         <groupId>org.axonframework.extensions.multitenancy</groupId>
-        <version>4.9.0-SNAPSHOT</version>
+        <version>4.9.0</version>
     </parent>
 
     <artifactId>axon-multitenancy-spring-boot-autoconfigure</artifactId>

--- a/multitenancy-spring-boot-autoconfigure/pom.xml
+++ b/multitenancy-spring-boot-autoconfigure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>axon-multitenancy-parent</artifactId>
         <groupId>org.axonframework.extensions.multitenancy</groupId>
-        <version>4.9.0</version>
+        <version>4.9.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>axon-multitenancy-spring-boot-autoconfigure</artifactId>

--- a/multitenancy-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/multitenancy/autoconfig/AxonServerTenantProvider.java
+++ b/multitenancy-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/multitenancy/autoconfig/AxonServerTenantProvider.java
@@ -174,7 +174,7 @@ public class AxonServerTenantProvider implements TenantProvider, Lifecycle {
         return new TenantDescriptor(context.getName(), metaDataMap);
     }
 
-    protected void addTenant(TenantDescriptor tenantDescriptor) {
+    public void addTenant(TenantDescriptor tenantDescriptor) {
         tenantDescriptors.add(tenantDescriptor);
         tenantAwareComponents
                 .forEach(bus -> registrationMap

--- a/multitenancy-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/multitenancy/autoconfig/AxonServerTenantProvider.java
+++ b/multitenancy-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/multitenancy/autoconfig/AxonServerTenantProvider.java
@@ -174,6 +174,15 @@ public class AxonServerTenantProvider implements TenantProvider, Lifecycle {
         return new TenantDescriptor(context.getName(), metaDataMap);
     }
 
+    /**
+     * Adds a new tenant to the system.
+     *
+     * This method adds the provided {@link TenantDescriptor} to the set of known tenants.
+     * Once added all {@link MultiTenantAwareComponent MultiTenantAwareComponents} are registered and started for the
+     * new tenant.
+     *
+     * @param tenantDescriptor the {@link TenantDescriptor} representing the tenant to be added.
+     */
     public void addTenant(TenantDescriptor tenantDescriptor) {
         tenantDescriptors.add(tenantDescriptor);
         tenantAwareComponents
@@ -182,6 +191,17 @@ public class AxonServerTenantProvider implements TenantProvider, Lifecycle {
                         .add(bus.registerAndStartTenant(tenantDescriptor)));
     }
 
+    /**
+     * Removes a tenant from the system.
+     *
+     * This method checks if the provided {@link TenantDescriptor} is in the set of known tenants.
+     * If it is, the method removes the tenant and cancels all its registrations.
+     * {@link MultiTenantAwareComponent MultiTenantAwareComponents} are then unregistered in reverse order of their
+     * registration.
+     * It then disconnects the tenant from the Axon Server.
+     *
+     * @param tenantDescriptor the {@link TenantDescriptor} representing the tenant to be removed.
+     */
     public void removeTenant(TenantDescriptor tenantDescriptor) {
         if (tenantDescriptors.contains(tenantDescriptor) && tenantDescriptors.remove(tenantDescriptor)) {
             List<Registration> registrations = registrationMap.remove(tenantDescriptor);

--- a/multitenancy-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/multitenancy/autoconfig/AxonServerTenantProvider.java
+++ b/multitenancy-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/multitenancy/autoconfig/AxonServerTenantProvider.java
@@ -182,7 +182,7 @@ public class AxonServerTenantProvider implements TenantProvider, Lifecycle {
                         .add(bus.registerAndStartTenant(tenantDescriptor)));
     }
 
-    protected void removeTenant(TenantDescriptor tenantDescriptor) {
+    public void removeTenant(TenantDescriptor tenantDescriptor) {
         if (tenantDescriptors.contains(tenantDescriptor) && tenantDescriptors.remove(tenantDescriptor)) {
             List<Registration> registrations = registrationMap.remove(tenantDescriptor);
             if (registrations != null && !registrations.isEmpty()) {

--- a/multitenancy-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/multitenancy/autoconfig/MultiTenancyAutoConfiguration.java
+++ b/multitenancy-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/multitenancy/autoconfig/MultiTenancyAutoConfiguration.java
@@ -35,6 +35,7 @@ import org.axonframework.extensions.multitenancy.components.queryhandeling.Tenan
 import org.axonframework.extensions.multitenancy.components.scheduling.MultiTenantEventScheduler;
 import org.axonframework.extensions.multitenancy.components.scheduling.TenantEventSchedulerSegmentFactory;
 import org.axonframework.extensions.multitenancy.configuration.MultiTenantEventProcessingModule;
+import org.axonframework.extensions.multitenancy.configuration.MultiTenantEventProcessorPredicate;
 import org.axonframework.extensions.multitenancy.configuration.MultiTenantStreamableMessageSourceProvider;
 import org.axonframework.messaging.Message;
 import org.axonframework.messaging.correlation.CorrelationDataProvider;
@@ -188,13 +189,23 @@ public class MultiTenancyAutoConfiguration {
     }
 
     @Bean
+    @ConditionalOnMissingBean
+    public MultiTenantEventProcessorPredicate multiTenantEventProcessorPredicate() {
+        return (processorName) -> true;
+    }
+
+    @Bean
     public MultiTenantEventProcessingModule multiTenantEventProcessingModule(
             TenantProvider tenantProvider,
             MultiTenantStreamableMessageSourceProvider multiTenantStreamableMessageSourceProvider,
-            MultiTenantDeadLetterQueueFactory<EventMessage<?>> multiTenantDeadLetterQueueFactory
+            MultiTenantDeadLetterQueueFactory<EventMessage<?>> multiTenantDeadLetterQueueFactory,
+            MultiTenantEventProcessorPredicate multiTenantEventProcessorPredicate
     ) {
         return new MultiTenantEventProcessingModule(
-                tenantProvider, multiTenantStreamableMessageSourceProvider, multiTenantDeadLetterQueueFactory
+                tenantProvider,
+                multiTenantStreamableMessageSourceProvider,
+                multiTenantDeadLetterQueueFactory,
+                multiTenantEventProcessorPredicate
         );
     }
 

--- a/multitenancy-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/multitenancy/autoconfig/MultiTenancyAutoConfiguration.java
+++ b/multitenancy-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/multitenancy/autoconfig/MultiTenancyAutoConfiguration.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2024. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -191,7 +191,7 @@ public class MultiTenancyAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean
     public MultiTenantEventProcessorPredicate multiTenantEventProcessorPredicate() {
-        return (processorName) -> true;
+        return MultiTenantEventProcessorPredicate.enableMultiTenancy();
     }
 
     @Bean

--- a/multitenancy-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/multitenancy/autoconfig/MultiTenantEventProcessorControlService.java
+++ b/multitenancy-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/multitenancy/autoconfig/MultiTenantEventProcessorControlService.java
@@ -158,10 +158,6 @@ public class MultiTenantEventProcessorControlService
                               .collect(toMap(Map.Entry::getKey, entry -> entry.getValue().getLoadBalancingStrategy()));
     }
 
-    private static String contextFromCombination(String processorAndContext) {
-        return processorAndContext.substring(processorAndContext.indexOf("@") + 1);
-    }
-
     private void registerInstructionHandler(ControlChannel controlChannel,
                                             String processorAndContext,
                                             EventProcessor processor) {
@@ -211,7 +207,14 @@ public class MultiTenantEventProcessorControlService
     }
 
     private static String processorNameFromCombination(String processorAndContext) {
-        return processorAndContext.substring(0, processorAndContext.indexOf("@"));
+        int index = processorAndContext.indexOf("@");
+        return index == -1 ? processorAndContext : processorAndContext.substring(0, index);
+    }
+
+    private static String contextFromCombination(String processorAndContext) {
+        int index = processorAndContext.indexOf("@");
+        //if there is no context name in the processorAndContext, return the _admin as default
+        return index == -1 ? "_admin" : processorAndContext.substring(index + 1);
     }
 
     @Override

--- a/multitenancy-spring-boot-autoconfigure/src/test/java/org/axonframework/extensions/multitenancy/autoconfig/MultiTenantEventProcessorControlServiceTest.java
+++ b/multitenancy-spring-boot-autoconfigure/src/test/java/org/axonframework/extensions/multitenancy/autoconfig/MultiTenantEventProcessorControlServiceTest.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableMap;
 import io.axoniq.axonserver.connector.AxonServerConnection;
 import io.axoniq.axonserver.connector.admin.AdminChannel;
 import io.axoniq.axonserver.connector.control.ControlChannel;
+import io.axoniq.axonserver.grpc.admin.Admin;
 import org.axonframework.axonserver.connector.AxonServerConfiguration;
 import org.axonframework.axonserver.connector.AxonServerConnectionManager;
 import org.axonframework.config.EventProcessingConfiguration;
@@ -52,6 +53,9 @@ class MultiTenantEventProcessorControlServiceTest {
     private EventProcessingConfiguration eventProcessingConfiguration;
 
     private ControlChannel controlTenant1;
+    private ControlChannel controlAdmin;
+
+    private AdminChannel adminAdmin;
     private AdminChannel adminTenant1;
     private ControlChannel controlTenant2;
     private AdminChannel adminTenant2;
@@ -77,6 +81,15 @@ class MultiTenantEventProcessorControlServiceTest {
     }
 
     private void mockConnectionManager() {
+        AxonServerConnection connectionAdmin = mock(AxonServerConnection.class);
+        controlAdmin = mock(ControlChannel.class);
+        adminAdmin = mock(AdminChannel.class);
+        when(connectionAdmin.controlChannel()).thenReturn(controlAdmin);
+        when(connectionAdmin.adminChannel()).thenReturn(adminAdmin);
+        when(adminAdmin.loadBalanceEventProcessor(any(), any(), any()))
+                .thenReturn(CompletableFuture.completedFuture(null));
+        when(adminAdmin.setAutoLoadBalanceStrategy(any(), any(), any()))
+                .thenReturn(CompletableFuture.completedFuture(null));
         AxonServerConnection connectionTenant1 = mock(AxonServerConnection.class);
         controlTenant1 = mock(ControlChannel.class);
         when(connectionTenant1.controlChannel()).thenReturn(controlTenant1);
@@ -97,7 +110,18 @@ class MultiTenantEventProcessorControlServiceTest {
         when(connectionTenant2.adminChannel()).thenReturn(adminTenant2);
         ArgumentCaptor<String> contextCapture = ArgumentCaptor.forClass(String.class);
         when(axonServerConnectionManager.getConnection(contextCapture.capture()))
-                .thenAnswer(a -> contextCapture.getValue().equals("tenant-1") ? connectionTenant1 : connectionTenant2);
+                .thenAnswer(a -> {
+                    String capturedValue = contextCapture.getValue();
+                    if (capturedValue.equals("tenant-1")) {
+                        return connectionTenant1;
+                    } else if (capturedValue.equals("tenant-2")) {
+                        return connectionTenant2;
+                    } else if (capturedValue.equals("_admin")) {
+                        return connectionAdmin;
+                    } else {
+                        throw new IllegalArgumentException("Unexpected value: " + capturedValue);
+                    }
+                });
     }
 
     private static void mockAxonServerConfig(AxonServerConfiguration axonServerConfig) {
@@ -124,6 +148,17 @@ class MultiTenantEventProcessorControlServiceTest {
 
         verify(controlTenant1).registerEventProcessor(eq(PROCESSOR_NAME + "@tenant-1"), any(), any());
         verify(controlTenant2).registerEventProcessor(eq(PROCESSOR_NAME + "@tenant-2"), any(), any());
+    }
+
+    @Test
+    void registersInstructionHandlersWithoutTenantOnStart() {
+        when(eventProcessingConfiguration.eventProcessors()).thenReturn(ImmutableMap.of(
+                PROCESSOR_NAME , mock(EventProcessor.class)
+        ));
+
+        testSubject.start();
+
+        verify(controlAdmin).registerEventProcessor(eq(PROCESSOR_NAME), any(), any());
     }
 
     @Test

--- a/multitenancy-spring-boot-starter/pom.xml
+++ b/multitenancy-spring-boot-starter/pom.xml
@@ -25,7 +25,7 @@
 
     <groupId>org.axonframework.extensions.multitenancy</groupId>
     <artifactId>axon-multitenancy-spring-boot-starter</artifactId>
-    <version>4.9.0</version>
+    <version>4.9.1-SNAPSHOT</version>
 
     <name>Spring Boot Starter module for Axon Framework Multi-Tenancy Extension</name>
     <description>Spring Boot Starter module for the Multi-Tenancy Extension of Axon Framework</description>
@@ -170,6 +170,6 @@
         <connection>scm:git:git://github.com/AxonFramework/extension-multitenancy.git</connection>
         <developerConnection>scm:git:git@github.com:AxonFramework/extension-multitenancy.git</developerConnection>
         <url>https://github.com/AxonFramework/extension-multitenancy</url>
-        <tag>axon-multi-tenancy-4.9.0</tag>
+        <tag>HEAD</tag>
     </scm>
 </project>

--- a/multitenancy-spring-boot-starter/pom.xml
+++ b/multitenancy-spring-boot-starter/pom.xml
@@ -14,19 +14,18 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starters</artifactId>
         <version>2.2.13.RELEASE</version>
-        <relativePath/>
+        <relativePath />
     </parent>
 
     <groupId>org.axonframework.extensions.multitenancy</groupId>
     <artifactId>axon-multitenancy-spring-boot-starter</artifactId>
-    <version>4.9.0-SNAPSHOT</version>
+    <version>4.9.0</version>
 
     <name>Spring Boot Starter module for Axon Framework Multi-Tenancy Extension</name>
     <description>Spring Boot Starter module for the Multi-Tenancy Extension of Axon Framework</description>
@@ -171,6 +170,6 @@
         <connection>scm:git:git://github.com/AxonFramework/extension-multitenancy.git</connection>
         <developerConnection>scm:git:git@github.com:AxonFramework/extension-multitenancy.git</developerConnection>
         <url>https://github.com/AxonFramework/extension-multitenancy</url>
-        <tag>HEAD</tag>
+        <tag>axon-multi-tenancy-4.9.0</tag>
     </scm>
 </project>

--- a/multitenancy/pom.xml
+++ b/multitenancy/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>axon-multitenancy-parent</artifactId>
         <groupId>org.axonframework.extensions.multitenancy</groupId>
-        <version>4.9.0</version>
+        <version>4.9.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>axon-multitenancy</artifactId>

--- a/multitenancy/pom.xml
+++ b/multitenancy/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>axon-multitenancy-parent</artifactId>
         <groupId>org.axonframework.extensions.multitenancy</groupId>
-        <version>4.9.0-SNAPSHOT</version>
+        <version>4.9.0</version>
     </parent>
 
     <artifactId>axon-multitenancy</artifactId>

--- a/multitenancy/src/main/java/org/axonframework/extensions/multitenancy/configuration/MultiTenantEventProcessingModule.java
+++ b/multitenancy/src/main/java/org/axonframework/extensions/multitenancy/configuration/MultiTenantEventProcessingModule.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2024. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -80,7 +80,7 @@ public class MultiTenantEventProcessingModule extends EventProcessingModule {
         this.tenantProvider = tenantProvider;
         this.multiTenantDeadLetterQueueFactory = null;
         this.multiTenantStreamableMessageSourceProvider = ((defaultSource, processorName, tenantDescriptor, configuration) -> defaultSource);
-        this.multiTenantEventProcessorPredicate = (name) -> true;
+        this.multiTenantEventProcessorPredicate = MultiTenantEventProcessorPredicate.enableMultiTenancy();
     }
 
     /**
@@ -100,7 +100,7 @@ public class MultiTenantEventProcessingModule extends EventProcessingModule {
         this.tenantProvider = tenantProvider;
         this.multiTenantDeadLetterQueueFactory = multiTenantDeadLetterQueueFactory;
         multiTenantStreamableMessageSourceProvider = ((defaultSource, processorName, tenantDescriptor, configuration) -> defaultSource);
-        this.multiTenantEventProcessorPredicate = (name) -> true;
+        this.multiTenantEventProcessorPredicate = MultiTenantEventProcessorPredicate.enableMultiTenancy();
     }
 
     /**
@@ -198,15 +198,15 @@ public class MultiTenantEventProcessingModule extends EventProcessingModule {
 
     private SubscribingEventProcessor buildSep(String name, EventHandlerInvoker eventHandlerInvoker, SubscribableMessageSource<? extends EventMessage<?>> source, TransactionManager transactionManager) {
         return SubscribingEventProcessor.builder()
-                .name(name)
-                .eventHandlerInvoker(eventHandlerInvoker)
-                .rollbackConfiguration(super.rollbackConfiguration(name))
-                .errorHandler(super.errorHandler(name))
-                .messageMonitor(super.messageMonitor(SubscribingEventProcessor.class, name))
-                .messageSource(source)
-                .processingStrategy(DirectEventProcessingStrategy.INSTANCE)
-                .transactionManager(transactionManager)
-                .build();
+                                        .name(name)
+                                        .eventHandlerInvoker(eventHandlerInvoker)
+                                        .rollbackConfiguration(super.rollbackConfiguration(name))
+                                        .errorHandler(super.errorHandler(name))
+                                        .messageMonitor(super.messageMonitor(SubscribingEventProcessor.class, name))
+                                        .messageSource(source)
+                                        .processingStrategy(DirectEventProcessingStrategy.INSTANCE)
+                                        .transactionManager(transactionManager)
+                                        .build();
     }
 
     private SubscribingEventProcessor buildSep(TenantDescriptor tenantDescriptor, String name, EventHandlerInvoker eventHandlerInvoker, SubscribableMessageSource<? extends EventMessage<?>> source) {
@@ -254,16 +254,16 @@ public class MultiTenantEventProcessingModule extends EventProcessingModule {
 
     private TrackingEventProcessor buildTep(String name, EventHandlerInvoker eventHandlerInvoker, StreamableMessageSource<TrackedEventMessage<?>> source, TransactionManager transactionManager, TrackingEventProcessorConfiguration config) {
         return TrackingEventProcessor.builder()
-                .name(name)
-                .eventHandlerInvoker(eventHandlerInvoker)
-                .rollbackConfiguration(super.rollbackConfiguration(name))
-                .errorHandler(super.errorHandler(name))
-                .messageMonitor(super.messageMonitor(TrackingEventProcessor.class, name))
-                .messageSource(source)
-                .tokenStore(super.tokenStore(name))
-                .transactionManager(transactionManager)
-                .trackingEventProcessorConfiguration(config)
-                .build();
+                                     .name(name)
+                                     .eventHandlerInvoker(eventHandlerInvoker)
+                                     .rollbackConfiguration(super.rollbackConfiguration(name))
+                                     .errorHandler(super.errorHandler(name))
+                                     .messageMonitor(super.messageMonitor(TrackingEventProcessor.class, name))
+                                     .messageSource(source)
+                                     .tokenStore(super.tokenStore(name))
+                                     .transactionManager(transactionManager)
+                                     .trackingEventProcessorConfiguration(config)
+                                     .build();
     }
 
     private TrackingEventProcessor buildTep(TenantDescriptor tenantDescriptor, String name, EventHandlerInvoker eventHandlerInvoker, StreamableMessageSource<TrackedEventMessage<?>> source, TrackingEventProcessorConfiguration config) {
@@ -332,24 +332,24 @@ public class MultiTenantEventProcessingModule extends EventProcessingModule {
 
     private PooledStreamingEventProcessor.Builder psepBuilder(String name, EventHandlerInvoker eventHandlerInvoker, StreamableMessageSource<TrackedEventMessage<?>> source, TransactionManager transactionManager, Configuration config) {
         return PooledStreamingEventProcessor.builder()
-                .name(name)
-                .eventHandlerInvoker(eventHandlerInvoker)
-                .rollbackConfiguration(super.rollbackConfiguration(name))
-                .errorHandler(super.errorHandler(name))
-                .messageMonitor(super.messageMonitor(PooledStreamingEventProcessor.class, name))
-                .messageSource(source)
-                .tokenStore(super.tokenStore(name))
-                .transactionManager(transactionManager)
-                .coordinatorExecutor(processorName -> {
-                    ScheduledExecutorService coordinatorExecutor = defaultExecutor("Coordinator[" + processorName + "]");
-                    config.onShutdown(coordinatorExecutor::shutdown);
-                    return coordinatorExecutor;
-                })
-                .workerExecutor(processorName -> {
-                    ScheduledExecutorService workerExecutor = defaultExecutor("WorkPackage[" + processorName + "]");
-                    config.onShutdown(workerExecutor::shutdown);
-                    return workerExecutor;
-                });
+                                            .name(name)
+                                            .eventHandlerInvoker(eventHandlerInvoker)
+                                            .rollbackConfiguration(super.rollbackConfiguration(name))
+                                            .errorHandler(super.errorHandler(name))
+                                            .messageMonitor(super.messageMonitor(PooledStreamingEventProcessor.class, name))
+                                            .messageSource(source)
+                                            .tokenStore(super.tokenStore(name))
+                                            .transactionManager(transactionManager)
+                                            .coordinatorExecutor(processorName -> {
+                                                ScheduledExecutorService coordinatorExecutor = defaultExecutor("Coordinator[" + processorName + "]");
+                                                config.onShutdown(coordinatorExecutor::shutdown);
+                                                return coordinatorExecutor;
+                                            })
+                                            .workerExecutor(processorName -> {
+                                                ScheduledExecutorService workerExecutor = defaultExecutor("WorkPackage[" + processorName + "]");
+                                                config.onShutdown(workerExecutor::shutdown);
+                                                return workerExecutor;
+                                            });
     }
 
     private PooledStreamingEventProcessor.Builder psepBuilder(TenantDescriptor tenantDescriptor, String name, EventHandlerInvoker eventHandlerInvoker, StreamableMessageSource<TrackedEventMessage<?>> source, Configuration config) {

--- a/multitenancy/src/main/java/org/axonframework/extensions/multitenancy/configuration/MultiTenantEventProcessingModule.java
+++ b/multitenancy/src/main/java/org/axonframework/extensions/multitenancy/configuration/MultiTenantEventProcessingModule.java
@@ -17,6 +17,7 @@ package org.axonframework.extensions.multitenancy.configuration;
 
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.AxonThreadFactory;
+import org.axonframework.common.transaction.TransactionManager;
 import org.axonframework.config.Configuration;
 import org.axonframework.config.EventProcessingConfigurer;
 import org.axonframework.config.EventProcessingModule;
@@ -64,6 +65,8 @@ public class MultiTenantEventProcessingModule extends EventProcessingModule {
     private final TenantProvider tenantProvider;
     private final MultiTenantStreamableMessageSourceProvider multiTenantStreamableMessageSourceProvider;
 
+    private final MultiTenantEventProcessorPredicate multiTenantEventProcessorPredicate;
+
     protected final MultiTenantDeadLetterQueueFactory<EventMessage<?>> multiTenantDeadLetterQueueFactory;
 
     /**
@@ -76,7 +79,8 @@ public class MultiTenantEventProcessingModule extends EventProcessingModule {
     public MultiTenantEventProcessingModule(TenantProvider tenantProvider) {
         this.tenantProvider = tenantProvider;
         this.multiTenantDeadLetterQueueFactory = null;
-        multiTenantStreamableMessageSourceProvider = ((defaultSource, processorName, tenantDescriptor, configuration) -> defaultSource);
+        this.multiTenantStreamableMessageSourceProvider = ((defaultSource, processorName, tenantDescriptor, configuration) -> defaultSource);
+        this.multiTenantEventProcessorPredicate = (name) -> true;
     }
 
     /**
@@ -96,6 +100,7 @@ public class MultiTenantEventProcessingModule extends EventProcessingModule {
         this.tenantProvider = tenantProvider;
         this.multiTenantDeadLetterQueueFactory = multiTenantDeadLetterQueueFactory;
         multiTenantStreamableMessageSourceProvider = ((defaultSource, processorName, tenantDescriptor, configuration) -> defaultSource);
+        this.multiTenantEventProcessorPredicate = (name) -> true;
     }
 
     /**
@@ -115,9 +120,11 @@ public class MultiTenantEventProcessingModule extends EventProcessingModule {
     public MultiTenantEventProcessingModule(
             TenantProvider tenantProvider,
             MultiTenantStreamableMessageSourceProvider multiTenantStreamableMessageSourceProvider,
-            MultiTenantDeadLetterQueueFactory<EventMessage<?>> multiTenantDeadLetterQueueFactory
+            MultiTenantDeadLetterQueueFactory<EventMessage<?>> multiTenantDeadLetterQueueFactory,
+            MultiTenantEventProcessorPredicate multiTenantEventProcessorPredicate
     ) {
         this.tenantProvider = tenantProvider;
+        this.multiTenantEventProcessorPredicate = multiTenantEventProcessorPredicate;
         this.multiTenantDeadLetterQueueFactory = multiTenantDeadLetterQueueFactory;
         this.multiTenantStreamableMessageSourceProvider = multiTenantStreamableMessageSourceProvider;
     }
@@ -159,6 +166,11 @@ public class MultiTenantEventProcessingModule extends EventProcessingModule {
     public EventProcessor subscribingEventProcessor(String name,
                                                     EventHandlerInvoker eventHandlerInvoker,
                                                     SubscribableMessageSource<? extends EventMessage<?>> messageSource) {
+
+        if (!multiTenantEventProcessorPredicate.test(name)) {
+           return buildSep(name, eventHandlerInvoker, messageSource);
+        }
+
         MultiTenantEventProcessor eventProcessor =
                 MultiTenantEventProcessor.builder()
                                          .name(name)
@@ -184,22 +196,26 @@ public class MultiTenantEventProcessingModule extends EventProcessingModule {
                 : messageSource;
     }
 
-    private SubscribingEventProcessor buildSep(TenantDescriptor tenantDescriptor,
-                                               String name,
-                                               EventHandlerInvoker eventHandlerInvoker,
-                                               SubscribableMessageSource<? extends EventMessage<?>> source) {
+    private SubscribingEventProcessor buildSep(String name, EventHandlerInvoker eventHandlerInvoker, SubscribableMessageSource<? extends EventMessage<?>> source, TenantDescriptor tenantDescriptor, TransactionManager transactionManager) {
         return SubscribingEventProcessor.builder()
-                                        .name(getName(name, tenantDescriptor))
-                                        .eventHandlerInvoker(eventHandlerInvoker)
-                                        .rollbackConfiguration(super.rollbackConfiguration(name))
-                                        .errorHandler(super.errorHandler(name))
-                                        .messageMonitor(super.messageMonitor(SubscribingEventProcessor.class, name))
-                                        .messageSource(source)
-                                        .processingStrategy(DirectEventProcessingStrategy.INSTANCE)
-                                        .transactionManager(new TenantWrappedTransactionManager(
-                                                super.transactionManager(name), tenantDescriptor
-                                        ))
-                                        .build();
+                .name(name)
+                .eventHandlerInvoker(eventHandlerInvoker)
+                .rollbackConfiguration(super.rollbackConfiguration(name))
+                .errorHandler(super.errorHandler(name))
+                .messageMonitor(super.messageMonitor(SubscribingEventProcessor.class, name))
+                .messageSource(source)
+                .processingStrategy(DirectEventProcessingStrategy.INSTANCE)
+                .transactionManager(transactionManager)
+                .build();
+    }
+
+    private SubscribingEventProcessor buildSep(TenantDescriptor tenantDescriptor, String name, EventHandlerInvoker eventHandlerInvoker, SubscribableMessageSource<? extends EventMessage<?>> source) {
+        TransactionManager transactionManager = new TenantWrappedTransactionManager(super.transactionManager(name), tenantDescriptor);
+        return buildSep(getName(name, tenantDescriptor), eventHandlerInvoker, source, tenantDescriptor, transactionManager);
+    }
+
+    private SubscribingEventProcessor buildSep(String name, EventHandlerInvoker eventHandlerInvoker, SubscribableMessageSource<? extends EventMessage<?>> source) {
+        return buildSep(name, eventHandlerInvoker, source, null, super.transactionManager(name));
     }
 
     @Override
@@ -207,6 +223,10 @@ public class MultiTenantEventProcessingModule extends EventProcessingModule {
                                                  EventHandlerInvoker eventHandlerInvoker,
                                                  TrackingEventProcessorConfiguration config,
                                                  StreamableMessageSource<TrackedEventMessage<?>> source) {
+        if (!multiTenantEventProcessorPredicate.test(name)) {
+            return buildTep(name, eventHandlerInvoker, source, config);
+        }
+
         MultiTenantEventProcessor eventProcessor =
                 MultiTenantEventProcessor.builder()
                                          .name(name)
@@ -232,32 +252,38 @@ public class MultiTenantEventProcessingModule extends EventProcessingModule {
         return eventProcessor;
     }
 
-    private TrackingEventProcessor buildTep(TenantDescriptor tenantDescriptor,
-                                            String name,
-                                            EventHandlerInvoker eventHandlerInvoker,
-                                            StreamableMessageSource<TrackedEventMessage<?>> source,
-                                            TrackingEventProcessorConfiguration config) {
+    private TrackingEventProcessor buildTep(String name, EventHandlerInvoker eventHandlerInvoker, StreamableMessageSource<TrackedEventMessage<?>> source, TenantDescriptor tenantDescriptor, TransactionManager transactionManager, TrackingEventProcessorConfiguration config) {
         return TrackingEventProcessor.builder()
-                                     .name(getName(name, tenantDescriptor))
-                                     .eventHandlerInvoker(eventHandlerInvoker)
-                                     .rollbackConfiguration(super.rollbackConfiguration(name))
-                                     .errorHandler(super.errorHandler(name))
-                                     .messageMonitor(super.messageMonitor(TrackingEventProcessor.class, name))
-                                     .messageSource(source)
-                                     .tokenStore(super.tokenStore(name))
-                                     .transactionManager(new TenantWrappedTransactionManager(
-                                             super.transactionManager(name), tenantDescriptor
-                                     ))
-                                     .trackingEventProcessorConfiguration(config)
-                                     .build();
+                .name(name)
+                .eventHandlerInvoker(eventHandlerInvoker)
+                .rollbackConfiguration(super.rollbackConfiguration(name))
+                .errorHandler(super.errorHandler(name))
+                .messageMonitor(super.messageMonitor(TrackingEventProcessor.class, name))
+                .messageSource(source)
+                .tokenStore(super.tokenStore(name))
+                .transactionManager(transactionManager)
+                .trackingEventProcessorConfiguration(config)
+                .build();
     }
 
+    private TrackingEventProcessor buildTep(TenantDescriptor tenantDescriptor, String name, EventHandlerInvoker eventHandlerInvoker, StreamableMessageSource<TrackedEventMessage<?>> source, TrackingEventProcessorConfiguration config) {
+        TransactionManager transactionManager = new TenantWrappedTransactionManager(super.transactionManager(name), tenantDescriptor);
+        return buildTep(getName(name, tenantDescriptor), eventHandlerInvoker, source, tenantDescriptor, transactionManager, config);
+    }
+
+    private TrackingEventProcessor buildTep(String name, EventHandlerInvoker eventHandlerInvoker, StreamableMessageSource<TrackedEventMessage<?>> source, TrackingEventProcessorConfiguration config) {
+        return buildTep(name, eventHandlerInvoker, source, null, super.transactionManager(name), config);
+    }
     @Override
     public EventProcessor pooledStreamingEventProcessor(String name,
                                                         EventHandlerInvoker eventHandlerInvoker,
                                                         Configuration config,
                                                         StreamableMessageSource<TrackedEventMessage<?>> source,
                                                         PooledStreamingProcessorConfiguration processorConfiguration) {
+        if (!multiTenantEventProcessorPredicate.test(name)) {
+            return psepBuilder(name, eventHandlerInvoker, source, config).build();
+        }
+
         MultiTenantEventProcessor eventProcessor =
                 MultiTenantEventProcessor.builder()
                                          .name(name)
@@ -304,36 +330,35 @@ public class MultiTenantEventProcessingModule extends EventProcessingModule {
                 : source;
     }
 
-    private PooledStreamingEventProcessor.Builder psepBuilder(TenantDescriptor tenantDescriptor,
-                                                              String name,
-                                                              EventHandlerInvoker eventHandlerInvoker,
-                                                              StreamableMessageSource<TrackedEventMessage<?>> source,
-                                                              Configuration config) {
+    private PooledStreamingEventProcessor.Builder psepBuilder(String name, EventHandlerInvoker eventHandlerInvoker, StreamableMessageSource<TrackedEventMessage<?>> source, TenantDescriptor tenantDescriptor, TransactionManager transactionManager, Configuration config) {
         return PooledStreamingEventProcessor.builder()
-                                            .name(getName(name, tenantDescriptor))
-                                            .eventHandlerInvoker(eventHandlerInvoker)
-                                            .rollbackConfiguration(super.rollbackConfiguration(name))
-                                            .errorHandler(super.errorHandler(name))
-                                            .messageMonitor(
-                                                    super.messageMonitor(PooledStreamingEventProcessor.class, name)
-                                            )
-                                            .messageSource(source)
-                                            .tokenStore(super.tokenStore(name))
-                                            .transactionManager(new TenantWrappedTransactionManager(
-                                                    super.transactionManager(name), tenantDescriptor
-                                            ))
-                                            .coordinatorExecutor(processorName -> {
-                                                ScheduledExecutorService coordinatorExecutor = defaultExecutor(
-                                                        "Coordinator[" + processorName + "]");
-                                                config.onShutdown(coordinatorExecutor::shutdown);
-                                                return coordinatorExecutor;
-                                            })
-                                            .workerExecutor(processorName -> {
-                                                ScheduledExecutorService workerExecutor = defaultExecutor(
-                                                        "WorkPackage[" + processorName + "]");
-                                                config.onShutdown(workerExecutor::shutdown);
-                                                return workerExecutor;
-                                            });
+                .name(name)
+                .eventHandlerInvoker(eventHandlerInvoker)
+                .rollbackConfiguration(super.rollbackConfiguration(name))
+                .errorHandler(super.errorHandler(name))
+                .messageMonitor(super.messageMonitor(PooledStreamingEventProcessor.class, name))
+                .messageSource(source)
+                .tokenStore(super.tokenStore(name))
+                .transactionManager(transactionManager)
+                .coordinatorExecutor(processorName -> {
+                    ScheduledExecutorService coordinatorExecutor = defaultExecutor("Coordinator[" + processorName + "]");
+                    config.onShutdown(coordinatorExecutor::shutdown);
+                    return coordinatorExecutor;
+                })
+                .workerExecutor(processorName -> {
+                    ScheduledExecutorService workerExecutor = defaultExecutor("WorkPackage[" + processorName + "]");
+                    config.onShutdown(workerExecutor::shutdown);
+                    return workerExecutor;
+                });
+    }
+
+    private PooledStreamingEventProcessor.Builder psepBuilder(TenantDescriptor tenantDescriptor, String name, EventHandlerInvoker eventHandlerInvoker, StreamableMessageSource<TrackedEventMessage<?>> source, Configuration config) {
+        TransactionManager transactionManager = new TenantWrappedTransactionManager(super.transactionManager(name), tenantDescriptor);
+        return psepBuilder(getName(name, tenantDescriptor), eventHandlerInvoker, source, tenantDescriptor, transactionManager, config);
+    }
+
+    private PooledStreamingEventProcessor.Builder psepBuilder(String name, EventHandlerInvoker eventHandlerInvoker, StreamableMessageSource<TrackedEventMessage<?>> source, Configuration config) {
+        return psepBuilder(name, eventHandlerInvoker, source, null, super.transactionManager(name), config);
     }
 
     /**

--- a/multitenancy/src/main/java/org/axonframework/extensions/multitenancy/configuration/MultiTenantEventProcessingModule.java
+++ b/multitenancy/src/main/java/org/axonframework/extensions/multitenancy/configuration/MultiTenantEventProcessingModule.java
@@ -196,7 +196,7 @@ public class MultiTenantEventProcessingModule extends EventProcessingModule {
                 : messageSource;
     }
 
-    private SubscribingEventProcessor buildSep(String name, EventHandlerInvoker eventHandlerInvoker, SubscribableMessageSource<? extends EventMessage<?>> source, TenantDescriptor tenantDescriptor, TransactionManager transactionManager) {
+    private SubscribingEventProcessor buildSep(String name, EventHandlerInvoker eventHandlerInvoker, SubscribableMessageSource<? extends EventMessage<?>> source, TransactionManager transactionManager) {
         return SubscribingEventProcessor.builder()
                 .name(name)
                 .eventHandlerInvoker(eventHandlerInvoker)
@@ -211,11 +211,11 @@ public class MultiTenantEventProcessingModule extends EventProcessingModule {
 
     private SubscribingEventProcessor buildSep(TenantDescriptor tenantDescriptor, String name, EventHandlerInvoker eventHandlerInvoker, SubscribableMessageSource<? extends EventMessage<?>> source) {
         TransactionManager transactionManager = new TenantWrappedTransactionManager(super.transactionManager(name), tenantDescriptor);
-        return buildSep(getName(name, tenantDescriptor), eventHandlerInvoker, source, tenantDescriptor, transactionManager);
+        return buildSep(getName(name, tenantDescriptor), eventHandlerInvoker, source, transactionManager);
     }
 
     private SubscribingEventProcessor buildSep(String name, EventHandlerInvoker eventHandlerInvoker, SubscribableMessageSource<? extends EventMessage<?>> source) {
-        return buildSep(name, eventHandlerInvoker, source, null, super.transactionManager(name));
+        return buildSep(name, eventHandlerInvoker, source, super.transactionManager(name));
     }
 
     @Override
@@ -252,7 +252,7 @@ public class MultiTenantEventProcessingModule extends EventProcessingModule {
         return eventProcessor;
     }
 
-    private TrackingEventProcessor buildTep(String name, EventHandlerInvoker eventHandlerInvoker, StreamableMessageSource<TrackedEventMessage<?>> source, TenantDescriptor tenantDescriptor, TransactionManager transactionManager, TrackingEventProcessorConfiguration config) {
+    private TrackingEventProcessor buildTep(String name, EventHandlerInvoker eventHandlerInvoker, StreamableMessageSource<TrackedEventMessage<?>> source, TransactionManager transactionManager, TrackingEventProcessorConfiguration config) {
         return TrackingEventProcessor.builder()
                 .name(name)
                 .eventHandlerInvoker(eventHandlerInvoker)
@@ -268,11 +268,11 @@ public class MultiTenantEventProcessingModule extends EventProcessingModule {
 
     private TrackingEventProcessor buildTep(TenantDescriptor tenantDescriptor, String name, EventHandlerInvoker eventHandlerInvoker, StreamableMessageSource<TrackedEventMessage<?>> source, TrackingEventProcessorConfiguration config) {
         TransactionManager transactionManager = new TenantWrappedTransactionManager(super.transactionManager(name), tenantDescriptor);
-        return buildTep(getName(name, tenantDescriptor), eventHandlerInvoker, source, tenantDescriptor, transactionManager, config);
+        return buildTep(getName(name, tenantDescriptor), eventHandlerInvoker, source, transactionManager, config);
     }
 
     private TrackingEventProcessor buildTep(String name, EventHandlerInvoker eventHandlerInvoker, StreamableMessageSource<TrackedEventMessage<?>> source, TrackingEventProcessorConfiguration config) {
-        return buildTep(name, eventHandlerInvoker, source, null, super.transactionManager(name), config);
+        return buildTep(name, eventHandlerInvoker, source, super.transactionManager(name), config);
     }
     @Override
     public EventProcessor pooledStreamingEventProcessor(String name,
@@ -330,7 +330,7 @@ public class MultiTenantEventProcessingModule extends EventProcessingModule {
                 : source;
     }
 
-    private PooledStreamingEventProcessor.Builder psepBuilder(String name, EventHandlerInvoker eventHandlerInvoker, StreamableMessageSource<TrackedEventMessage<?>> source, TenantDescriptor tenantDescriptor, TransactionManager transactionManager, Configuration config) {
+    private PooledStreamingEventProcessor.Builder psepBuilder(String name, EventHandlerInvoker eventHandlerInvoker, StreamableMessageSource<TrackedEventMessage<?>> source, TransactionManager transactionManager, Configuration config) {
         return PooledStreamingEventProcessor.builder()
                 .name(name)
                 .eventHandlerInvoker(eventHandlerInvoker)
@@ -354,11 +354,11 @@ public class MultiTenantEventProcessingModule extends EventProcessingModule {
 
     private PooledStreamingEventProcessor.Builder psepBuilder(TenantDescriptor tenantDescriptor, String name, EventHandlerInvoker eventHandlerInvoker, StreamableMessageSource<TrackedEventMessage<?>> source, Configuration config) {
         TransactionManager transactionManager = new TenantWrappedTransactionManager(super.transactionManager(name), tenantDescriptor);
-        return psepBuilder(getName(name, tenantDescriptor), eventHandlerInvoker, source, tenantDescriptor, transactionManager, config);
+        return psepBuilder(getName(name, tenantDescriptor), eventHandlerInvoker, source, transactionManager, config);
     }
 
     private PooledStreamingEventProcessor.Builder psepBuilder(String name, EventHandlerInvoker eventHandlerInvoker, StreamableMessageSource<TrackedEventMessage<?>> source, Configuration config) {
-        return psepBuilder(name, eventHandlerInvoker, source, null, super.transactionManager(name), config);
+        return psepBuilder(name, eventHandlerInvoker, source, super.transactionManager(name), config);
     }
 
     /**

--- a/multitenancy/src/main/java/org/axonframework/extensions/multitenancy/configuration/MultiTenantEventProcessorPredicate.java
+++ b/multitenancy/src/main/java/org/axonframework/extensions/multitenancy/configuration/MultiTenantEventProcessorPredicate.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2024. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -26,4 +26,12 @@ import java.util.function.Predicate;
  * @author Stefan Dragisic
  * @since 4.9.3
  */
-public interface MultiTenantEventProcessorPredicate extends Predicate<String> { }
+public interface MultiTenantEventProcessorPredicate extends Predicate<String> {
+    static MultiTenantEventProcessorPredicate enableMultiTenancy() {
+        return name -> true;
+    }
+
+    static MultiTenantEventProcessorPredicate disableMultiTenancy() {
+        return name -> false;
+    }
+}

--- a/multitenancy/src/main/java/org/axonframework/extensions/multitenancy/configuration/MultiTenantEventProcessorPredicate.java
+++ b/multitenancy/src/main/java/org/axonframework/extensions/multitenancy/configuration/MultiTenantEventProcessorPredicate.java
@@ -15,13 +15,15 @@
  */
 package org.axonframework.extensions.multitenancy.configuration;
 
-import org.axonframework.extensions.multitenancy.components.TenantDescriptor;
-
 import java.util.function.Predicate;
 
 /**
- * todo
+ * Represents a predicate to determine if an event processor should be multi-tenant.
+ *
+ * This interface extends {@link Predicate<String>} and is used to test whether a given event processor
+ * should be considered as multi-tenant. The input to the predicate is the name of the event processor.
+ *
+ * @author Stefan Dragisic
+ * @since 4.9.3
  */
-public interface MultiTenantEventProcessorPredicate extends Predicate<String> {
-
-}
+public interface MultiTenantEventProcessorPredicate extends Predicate<String> { }

--- a/multitenancy/src/main/java/org/axonframework/extensions/multitenancy/configuration/MultiTenantEventProcessorPredicate.java
+++ b/multitenancy/src/main/java/org/axonframework/extensions/multitenancy/configuration/MultiTenantEventProcessorPredicate.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2010-2023. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.axonframework.extensions.multitenancy.configuration;
+
+import org.axonframework.extensions.multitenancy.components.TenantDescriptor;
+
+import java.util.function.Predicate;
+
+/**
+ * todo
+ */
+public interface MultiTenantEventProcessorPredicate extends Predicate<String> {
+
+}

--- a/multitenancy/src/test/java/org/axonframework/extensions/multitenancy/configuration/MultiTenantEventProcessingModuleTest.java
+++ b/multitenancy/src/test/java/org/axonframework/extensions/multitenancy/configuration/MultiTenantEventProcessingModuleTest.java
@@ -19,6 +19,7 @@ package org.axonframework.extensions.multitenancy.configuration;
 import org.axonframework.config.Configuration;
 import org.axonframework.config.Configurer;
 import org.axonframework.config.DefaultConfigurer;
+import org.axonframework.eventhandling.EventHandler;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventhandling.SubscribingEventProcessor;
 import org.axonframework.eventhandling.TrackedEventMessage;
@@ -385,7 +386,7 @@ class MultiTenantEventProcessingModuleTest {
                   .usingPooledStreamingEventProcessors()
                   .configureDefaultStreamableMessageSource(config -> mockedSource)
                   .byDefaultAssignTo("default")
-                  .registerEventHandler(config -> new Object())
+                  .registerEventHandler(config -> new TestEventHandler())
                   .registerTrackingEventProcessorConfiguration("tracking", config -> testTepConfig);
         Configuration configuration = configurer.start();
 
@@ -414,5 +415,13 @@ class MultiTenantEventProcessingModuleTest {
                      });
 
         verify(customSource, times(2)).createHeadToken();
+    }
+
+    private static class TestEventHandler {
+
+        @EventHandler
+        public void handle(String event) {
+
+        }
     }
 }

--- a/multitenancy/src/test/java/org/axonframework/extensions/multitenancy/configuration/MultiTenantEventProcessingModuleTest.java
+++ b/multitenancy/src/test/java/org/axonframework/extensions/multitenancy/configuration/MultiTenantEventProcessingModuleTest.java
@@ -40,6 +40,7 @@ import org.axonframework.messaging.deadletter.SequencedDeadLetterQueue;
 import org.junit.jupiter.api.*;
 import org.mockito.*;
 
+import javax.sound.midi.Track;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -211,6 +212,39 @@ class MultiTenantEventProcessingModuleTest {
     }
 
     @Test
+    void trackingEventProcessorNonMultiTenant() {
+        //noinspection unchecked
+        StreamableMessageSource<TrackedEventMessage<?>> mockedSource = mock(StreamableMessageSource.class);
+        TenantProvider tenantProvider = mock(TenantProvider.class);
+        MultiTenantStreamableMessageSourceProvider multiTenantStreamableMessageSourceProvider =
+                (source, processorName, tenantDescriptor, configuration) -> source;
+        configurer.registerModule(
+                new MultiTenantEventProcessingModule(tenantProvider, multiTenantStreamableMessageSourceProvider, null, (name) -> false)
+        );
+
+        TrackingEventProcessorConfiguration testTepConfig =
+                TrackingEventProcessorConfiguration.forParallelProcessing(4);
+        configurer.eventProcessing()
+                .usingTrackingEventProcessors()
+                .configureDefaultStreamableMessageSource(config -> mockedSource)
+                .assignHandlerInstancesMatching("java.util.concurrent", "concurrent"::equals)
+                .registerEventHandler(c -> new Object()) // --> java.lang
+                .registerEventHandler(c -> "") // --> java.lang
+                .registerEventHandler(c -> "concurrent") // --> java.util.concurrent
+                .registerTrackingEventProcessorConfiguration("tracking", config -> testTepConfig);
+        Configuration configuration = configurer.start();
+
+
+        assertEquals(2, configuration.eventProcessingConfiguration().eventProcessors().size());
+        assertTrue(configuration.eventProcessingConfiguration()
+                .eventProcessor("java.util.concurrent", TrackingEventProcessor.class)
+                .isPresent());
+        assertTrue(configuration.eventProcessingConfiguration()
+                .eventProcessor("java.lang", TrackingEventProcessor.class)
+                .isPresent());
+    }
+
+    @Test
     void trackingEventProcessorCustomSource() {
         //noinspection unchecked
         StreamableMessageSource<TrackedEventMessage<?>> defaultSource = mock(StreamableMessageSource.class);
@@ -222,7 +256,7 @@ class MultiTenantEventProcessingModuleTest {
                 (source, processorName, tenantDescriptor, configuration) -> customSource;
 
         configurer.registerModule(
-                new MultiTenantEventProcessingModule(tenantProvider, multiTenantStreamableMessageSourceProvider, null)
+                new MultiTenantEventProcessingModule(tenantProvider, multiTenantStreamableMessageSourceProvider, null, (name) -> true)
         );
 
         TrackingEventProcessorConfiguration testTepConfig =
@@ -331,6 +365,32 @@ class MultiTenantEventProcessingModuleTest {
     }
 
     @Test
+    void subscribingEventProcessorNonMultiTenant() {
+        //noinspection unchecked
+        SubscribableMessageSource<EventMessage<?>> mockedSource = mock(SubscribableMessageSource.class);
+        TenantProvider tenantProvider = mock(TenantProvider.class);
+        MultiTenantStreamableMessageSourceProvider multiTenantStreamableMessageSourceProvider =
+                (source, processorName, tenantDescriptor, configuration) -> source;
+
+        configurer.registerModule(
+                new MultiTenantEventProcessingModule(tenantProvider, multiTenantStreamableMessageSourceProvider, null, (name) -> false)
+        );
+
+        configurer.eventProcessing()
+                .usingSubscribingEventProcessors()
+                .configureDefaultSubscribableMessageSource(config -> mockedSource)
+                .byDefaultAssignTo("subscribing")
+                .registerSubscribingEventProcessor("subscribing", config -> mockedSource)
+                .registerEventHandler(config -> new Object());
+        Configuration configuration = configurer.start();
+
+        assertEquals(1, configuration.eventProcessingConfiguration().eventProcessors().size());
+        assertTrue(configuration.eventProcessingConfiguration()
+                .eventProcessor("subscribing", SubscribingEventProcessor.class)
+                .isPresent());
+    }
+
+    @Test
     void pooledStreamingEventProcessor() {
         //noinspection unchecked
         StreamableMessageSource<TrackedEventMessage<?>> mockedSource = mock(StreamableMessageSource.class);
@@ -367,6 +427,36 @@ class MultiTenantEventProcessingModuleTest {
     }
 
     @Test
+    void pooledStreamingEventProcessorNonMultiTenant() {
+        //noinspection unchecked
+        StreamableMessageSource<TrackedEventMessage<?>> mockedSource = mock(StreamableMessageSource.class);
+        TenantProvider tenantProvider = mock(TenantProvider.class);
+        MultiTenantStreamableMessageSourceProvider multiTenantStreamableMessageSourceProvider =
+                (source, processorName, tenantDescriptor, configuration) -> source;
+
+        configurer.registerModule(
+                new MultiTenantEventProcessingModule(tenantProvider, multiTenantStreamableMessageSourceProvider, null, (name) -> false)
+        );
+
+        TrackingEventProcessorConfiguration testTepConfig =
+                TrackingEventProcessorConfiguration.forParallelProcessing(4);
+        configurer.eventProcessing()
+                .usingPooledStreamingEventProcessors()
+                .configureDefaultStreamableMessageSource(config -> mockedSource)
+                .byDefaultAssignTo("default")
+                .registerEventHandler(config -> new Object())
+                .registerTrackingEventProcessorConfiguration("tracking", config -> testTepConfig);
+        Configuration configuration = configurer.start();
+
+
+
+        assertEquals(1, configuration.eventProcessingConfiguration().eventProcessors().size());
+        assertTrue(configuration.eventProcessingConfiguration()
+                .eventProcessor("default", PooledStreamingEventProcessor.class)
+                .isPresent());
+    }
+
+    @Test
     void pooledStreamingEventProcessorCustomSource() {
         //noinspection unchecked
         StreamableMessageSource<TrackedEventMessage<?>> mockedSource = mock(StreamableMessageSource.class);
@@ -379,7 +469,7 @@ class MultiTenantEventProcessingModuleTest {
         TenantProvider tenantProvider = mock(TenantProvider.class);
         configurer.registerModule(new MultiTenantEventProcessingModule(tenantProvider,
                                                                        multiTenantStreamableMessageSourceProvider,
-                                                                       multiTenantDeadLetterQueueFactory));
+                                                                       multiTenantDeadLetterQueueFactory, (name) -> true));
         TrackingEventProcessorConfiguration testTepConfig =
                 TrackingEventProcessorConfiguration.forParallelProcessing(4);
         configurer.eventProcessing()

--- a/multitenancy/src/test/java/org/axonframework/extensions/multitenancy/configuration/MultiTenantEventProcessingModuleTest.java
+++ b/multitenancy/src/test/java/org/axonframework/extensions/multitenancy/configuration/MultiTenantEventProcessingModuleTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2024. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -215,7 +215,7 @@ class MultiTenantEventProcessingModuleTest {
         MultiTenantStreamableMessageSourceProvider multiTenantStreamableMessageSourceProvider =
                 (source, processorName, tenantDescriptor, configuration) -> source;
         configurer.registerModule(
-                new MultiTenantEventProcessingModule(tenantProvider, multiTenantStreamableMessageSourceProvider, null, (name) -> false)
+                new MultiTenantEventProcessingModule(tenantProvider, multiTenantStreamableMessageSourceProvider, null, MultiTenantEventProcessorPredicate.disableMultiTenancy())
         );
 
         TrackingEventProcessorConfiguration testTepConfig =
@@ -252,7 +252,7 @@ class MultiTenantEventProcessingModuleTest {
                 (source, processorName, tenantDescriptor, configuration) -> customSource;
 
         configurer.registerModule(
-                new MultiTenantEventProcessingModule(tenantProvider, multiTenantStreamableMessageSourceProvider, null, (name) -> true)
+                new MultiTenantEventProcessingModule(tenantProvider, multiTenantStreamableMessageSourceProvider, null, MultiTenantEventProcessorPredicate.enableMultiTenancy())
         );
 
         TrackingEventProcessorConfiguration testTepConfig =
@@ -369,7 +369,7 @@ class MultiTenantEventProcessingModuleTest {
                 (source, processorName, tenantDescriptor, configuration) -> source;
 
         configurer.registerModule(
-                new MultiTenantEventProcessingModule(tenantProvider, multiTenantStreamableMessageSourceProvider, null, (name) -> false)
+                new MultiTenantEventProcessingModule(tenantProvider, multiTenantStreamableMessageSourceProvider, null, MultiTenantEventProcessorPredicate.disableMultiTenancy())
         );
 
         configurer.eventProcessing()
@@ -431,7 +431,7 @@ class MultiTenantEventProcessingModuleTest {
                 (source, processorName, tenantDescriptor, configuration) -> source;
 
         configurer.registerModule(
-                new MultiTenantEventProcessingModule(tenantProvider, multiTenantStreamableMessageSourceProvider, null, (name) -> false)
+                new MultiTenantEventProcessingModule(tenantProvider, multiTenantStreamableMessageSourceProvider, null, MultiTenantEventProcessorPredicate.disableMultiTenancy())
         );
 
         TrackingEventProcessorConfiguration testTepConfig =
@@ -465,7 +465,7 @@ class MultiTenantEventProcessingModuleTest {
         TenantProvider tenantProvider = mock(TenantProvider.class);
         configurer.registerModule(new MultiTenantEventProcessingModule(tenantProvider,
                                                                        multiTenantStreamableMessageSourceProvider,
-                                                                       multiTenantDeadLetterQueueFactory, (name) -> true));
+                                                                       multiTenantDeadLetterQueueFactory, MultiTenantEventProcessorPredicate.enableMultiTenancy()));
         TrackingEventProcessorConfiguration testTepConfig =
                 TrackingEventProcessorConfiguration.forParallelProcessing(4);
         configurer.eventProcessing()

--- a/multitenancy/src/test/java/org/axonframework/extensions/multitenancy/configuration/MultiTenantEventProcessingModuleTest.java
+++ b/multitenancy/src/test/java/org/axonframework/extensions/multitenancy/configuration/MultiTenantEventProcessingModuleTest.java
@@ -19,12 +19,7 @@ package org.axonframework.extensions.multitenancy.configuration;
 import org.axonframework.config.Configuration;
 import org.axonframework.config.Configurer;
 import org.axonframework.config.DefaultConfigurer;
-import org.axonframework.eventhandling.EventHandler;
-import org.axonframework.eventhandling.EventMessage;
-import org.axonframework.eventhandling.SubscribingEventProcessor;
-import org.axonframework.eventhandling.TrackedEventMessage;
-import org.axonframework.eventhandling.TrackingEventProcessor;
-import org.axonframework.eventhandling.TrackingEventProcessorConfiguration;
+import org.axonframework.eventhandling.*;
 import org.axonframework.eventhandling.pooled.PooledStreamingEventProcessor;
 import org.axonframework.extensions.multitenancy.components.TargetTenantResolver;
 import org.axonframework.extensions.multitenancy.components.TenantDescriptor;
@@ -37,15 +32,16 @@ import org.axonframework.messaging.StreamableMessageSource;
 import org.axonframework.messaging.SubscribableMessageSource;
 import org.axonframework.messaging.deadletter.SequencedDeadLetterProcessor;
 import org.axonframework.messaging.deadletter.SequencedDeadLetterQueue;
-import org.junit.jupiter.api.*;
-import org.mockito.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
-import javax.sound.midi.Track;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
 /**

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <maven-gpg.version>3.1.0</maven-gpg.version>
         <maven-install.version>3.1.1</maven-install.version>
         <maven-jar.version>3.3.0</maven-jar.version>
-        <maven-javadoc.version>3.6.0</maven-javadoc.version>
+        <maven-javadoc.version>3.6.2</maven-javadoc.version>
         <maven-release.version>3.0.1</maven-release.version>
         <maven-source.version>3.3.0</maven-source.version>
         <maven-surefire.version>3.1.2</maven-surefire.version>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <groupId>org.axonframework.extensions.multitenancy</groupId>
     <artifactId>axon-multitenancy-parent</artifactId>
-    <version>4.9.0</version>
+    <version>4.9.1-SNAPSHOT</version>
     <modules>
         <module>multitenancy</module>
         <module>multitenancy-spring-boot-autoconfigure</module>
@@ -441,7 +441,7 @@
         <connection>scm:git:git://github.com/AxonFramework/extension-multitenancy.git</connection>
         <developerConnection>scm:git:git@github.com:AxonFramework/extension-multitenancy.git</developerConnection>
         <url>https://github.com/AxonFramework/extension-multitenancy</url>
-        <tag>axon-multi-tenancy-4.9.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <groupId>org.axonframework.extensions.multitenancy</groupId>
     <artifactId>axon-multitenancy-parent</artifactId>
-    <version>4.9.0-SNAPSHOT</version>
+    <version>4.9.0</version>
     <modules>
         <module>multitenancy</module>
         <module>multitenancy-spring-boot-autoconfigure</module>
@@ -90,27 +90,27 @@
             <dependency>
                 <groupId>org.axonframework</groupId>
                 <artifactId>axon-messaging</artifactId>
-                <version>${axon.version}</version>
+                <version>4.9.0</version>
             </dependency>
             <dependency>
                 <groupId>org.axonframework</groupId>
                 <artifactId>axon-configuration</artifactId>
-                <version>${axon.version}</version>
+                <version>4.9.0</version>
             </dependency>
             <dependency>
                 <groupId>org.axonframework</groupId>
                 <artifactId>axon-server-connector</artifactId>
-                <version>${axon.version}</version>
+                <version>4.9.0</version>
             </dependency>
             <dependency>
                 <groupId>org.axonframework</groupId>
                 <artifactId>axon-spring</artifactId>
-                <version>${axon.version}</version>
+                <version>4.9.0</version>
             </dependency>
             <dependency>
                 <groupId>org.axonframework</groupId>
                 <artifactId>axon-spring-boot-autoconfigure</artifactId>
-                <version>${axon.version}</version>
+                <version>4.9.0</version>
             </dependency>
             <!-- Reactor -->
             <dependency>
@@ -441,7 +441,7 @@
         <connection>scm:git:git://github.com/AxonFramework/extension-multitenancy.git</connection>
         <developerConnection>scm:git:git@github.com:AxonFramework/extension-multitenancy.git</developerConnection>
         <url>https://github.com/AxonFramework/extension-multitenancy</url>
-        <tag>HEAD</tag>
+        <tag>axon-multi-tenancy-4.9.0</tag>
     </scm>
 
     <developers>


### PR DESCRIPTION
In certain cases, users may want to disable multi-tenancy for specific Event Processor which does not have any tenants, such as when users have event processor that is consuming events from external context.
Per default, each event processor is scaled, and duplicated for each tenant. 

This PR allows to disable this behavior for a specific processing, you can define specific bean.

This PR also includes slight change that changes addTenant and removeTenant method visibility from protected to public in AxonServerTenantProvicder, as its benefitial for users to be able to access these methods directly.