### PR TITLE
Incorrect Spring Boot Auto-configuration ordering

### DIFF
--- a/multitenancy-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/multitenancy/autoconfig/MultiTenancyAxonServerAutoConfiguration.java
+++ b/multitenancy-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/multitenancy/autoconfig/MultiTenancyAxonServerAutoConfiguration.java
@@ -70,7 +70,7 @@ import org.springframework.core.env.Environment;
 @AutoConfiguration
 @ConditionalOnClass(AxonServerConfiguration.class)
 @ConditionalOnProperty(value = {"axon.axonserver.enabled", "axon.multi-tenancy.enabled"}, matchIfMissing = true)
-@AutoConfigureAfter(AxonServerAutoConfiguration.class)
+@AutoConfigureBefore(AxonServerAutoConfiguration.class)
 @ComponentScan(excludeFilters = {
         @ComponentScan.Filter(
                 type = FilterType.REGEX,

--- a/multitenancy-spring-boot-autoconfigure/src/test/java/org/axonframework/extensions/multitenancy/autoconfig/MultiTenancyAutoConfigurationTest.java
+++ b/multitenancy-spring-boot-autoconfigure/src/test/java/org/axonframework/extensions/multitenancy/autoconfig/MultiTenancyAutoConfigurationTest.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.extensions.multitenancy.autoconfig;
 
+import org.axonframework.axonserver.connector.event.axon.PersistentStreamMessageSource;
 import org.axonframework.axonserver.connector.event.axon.PersistentStreamMessageSourceFactory;
 import org.axonframework.extensions.multitenancy.components.TargetTenantResolver;
 import org.axonframework.extensions.multitenancy.components.TenantConnectPredicate;
@@ -39,6 +40,7 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
 
 /**
  * Test class validating the multi-tenancy auto-configuration.
@@ -119,6 +121,22 @@ class MultiTenancyAutoConfigurationTest {
                          assertThat(context).doesNotHaveBean(MultiTenantQueryUpdateEmitter.class);
                          assertThat(context).doesNotHaveBean(TenantPersistentStreamMessageSourceFactory.class);
                      });
+    }
+
+    @Test
+    void multiTenancyAutoConfigurationMultiTenantPersistentStreamMessageSource() {
+        contextRunner
+                .withConfiguration(AutoConfigurations.of(AxonServerAutoConfiguration.class))
+
+                .withConfiguration(AutoConfigurations.of(MultiTenancyAxonServerAutoConfiguration.class))
+                .withConfiguration(AutoConfigurations.of(MultiTenantPersistentStreamAutoConfiguration.class))
+                .withPropertyValues("axon.axonserver.contexts=tenant-1,tenant-2")
+                .run(context -> {
+                    PersistentStreamMessageSourceFactory persistentStreamMessageSourceFactory =
+                            context.getBean("persistentStreamMessageSourceFactory", PersistentStreamMessageSourceFactory.class);
+                    PersistentStreamMessageSource persistentStreamMessageSource = persistentStreamMessageSourceFactory.build("testName", mock(), mock(), 100, "testContext", mock());
+                    assertThat(persistentStreamMessageSource).isInstanceOf(MultiTenantPersistentStreamMessageSource.class);
+                });
     }
 
     @Test


### PR DESCRIPTION
Fixes misconfiguration, [MultiTenancyAxonServerAutoConfiguration.java](https://github.com/AxonFramework/extension-multitenancy/compare/axon-multitenancy-4.10.x...bugfix/multitenancyconfiguration?expand=1#diff-c68d3f314518bc8c81c218819614c20e408fe7fc63f58642484a197c7e959ad9) must be configured before AxonServerAutoConfiguration