### PR TITLE
Isolate SimpleCommandBus Instances per Tenant

### DIFF
--- a/docs/extension-guide/modules/ROOT/pages/configuration.adoc
+++ b/docs/extension-guide/modules/ROOT/pages/configuration.adoc
@@ -248,3 +248,29 @@ public MultiTenantEventProcessorPredicate multiTenantEventProcessorPredicate() {
 ----
 
 This bean should return `true` for each processor that you want to be multi-tenant, and `false` for each processor that you want to be single tenant.
+
+=== Tenant Segment Factories
+
+Axon Server Connector provides several factory beans that are used to create tenant-specific segments for various Axon components, such as Command Bus, Query Bus, Event Store, and Event Scheduler. These factories allow you to configure and customize the behavior of these components for each tenant.
+
+The following tenant segment factories are available:
+
+==== TenantCommandSegmentFactory
+
+This factory is responsible for creating a CommandBus instance for each tenant. By default, it creates an AxonServerCommandBus that uses a local SimpleCommandBus segment and connects to Axon Server. You can override this factory to provide a custom implementation of the CommandBus for specific tenants.
+
+==== TenantQuerySegmentFactory
+
+This factory creates a QueryBus instance for each tenant. By default, it creates an AxonServerQueryBus that uses a local SimpleQueryBus segment and connects to Axon Server. You can override this factory to provide a custom implementation of the QueryBus for specific tenants.
+
+==== TenantEventSegmentFactory
+
+This factory is responsible for creating an EventStore instance for each tenant. By default, it creates an AxonServerEventStore that connects to Axon Server. You can override this factory to provide a custom implementation of the EventStore for specific tenants.
+
+==== TenantEventSchedulerSegmentFactory
+
+This factory creates an EventScheduler instance for each tenant. By default, it creates an AxonServerEventScheduler that connects to Axon Server. You can override this factory to provide a custom implementation of the EventScheduler for specific tenants.
+
+==== TenantEventProcessorControlSegmentFactory
+
+This factory creates a TenantDescriptor for each event processor, which is used to identify the tenant associated with the event processor. By default, it uses the tenant ID as the TenantDescriptor. You can override this factory to provide a custom implementation of the TenantDescriptor for specific event processors.

--- a/docs/extension-guide/modules/ROOT/pages/configuration.adoc
+++ b/docs/extension-guide/modules/ROOT/pages/configuration.adoc
@@ -257,20 +257,20 @@ The following tenant segment factories are available:
 
 ==== TenantCommandSegmentFactory
 
-This factory is responsible for creating a CommandBus instance for each tenant. By default, it creates an AxonServerCommandBus that uses a local SimpleCommandBus segment and connects to Axon Server. You can override this factory to provide a custom implementation of the CommandBus for specific tenants.
+This factory is responsible for creating a `CommandBus` instance for each tenant. By default, it creates an `AxonServerCommandBus` that uses a `SimpleCommandBus` as the local segment and connects to Axon Server. You can override this factory to provide a custom implementation of the `CommandBus` for specific tenants.
 
 ==== TenantQuerySegmentFactory
 
-This factory creates a QueryBus instance for each tenant. By default, it creates an AxonServerQueryBus that uses a local SimpleQueryBus segment and connects to Axon Server. You can override this factory to provide a custom implementation of the QueryBus for specific tenants.
+This factory creates a `QueryBus` instance for each tenant. By default, it creates an `AxonServerQueryBus` that uses a `SimpleQueryBus` as lhe local segment and connects to Axon Server. You can override this factory to provide a custom implementation of the `QueryBus` for specific tenants.
 
 ==== TenantEventSegmentFactory
 
-This factory is responsible for creating an EventStore instance for each tenant. By default, it creates an AxonServerEventStore that connects to Axon Server. You can override this factory to provide a custom implementation of the EventStore for specific tenants.
+This factory is responsible for creating an `EventStore` instance for each tenant. By default, it creates an `AxonServerEventStore` that connects to Axon Server. You can override this factory to provide a custom implementation of the `EventStore` for specific tenants.
 
 ==== TenantEventSchedulerSegmentFactory
 
-This factory creates an EventScheduler instance for each tenant. By default, it creates an AxonServerEventScheduler that connects to Axon Server. You can override this factory to provide a custom implementation of the EventScheduler for specific tenants.
+This factory creates an `EventScheduler` instance for each tenant. By default, it creates an `AxonServerEventScheduler` that connects to Axon Server. You can override this factory to provide a custom implementation of the `EventScheduler` for specific tenants.
 
 ==== TenantEventProcessorControlSegmentFactory
 
-This factory creates a TenantDescriptor for each event processor, which is used to identify the tenant associated with the event processor. By default, it uses the tenant ID as the TenantDescriptor. You can override this factory to provide a custom implementation of the TenantDescriptor for specific event processors.
+This factory creates a `TenantDescriptor` for each event processor, which is used to identify the tenant associated with the event processor. By default, it uses the tenant identifier as the `TenantDescriptor`. You can override this factory to provide a custom implementation of the `TenantDescriptor` for specific event processors.

--- a/docs/extension-guide/modules/ROOT/pages/configuration.adoc
+++ b/docs/extension-guide/modules/ROOT/pages/configuration.adoc
@@ -251,7 +251,7 @@ This bean should return `true` for each processor that you want to be multi-tena
 
 === Tenant Segment Factories
 
-Axon Server Connector provides several factory beans that are used to create tenant-specific segments for various Axon components, such as Command Bus, Query Bus, Event Store, and Event Scheduler. These factories allow you to configure and customize the behavior of these components for each tenant.
+This extension provides several factory interfaces that are used to create tenant-specific segments for various Axon components, such as Command Bus, Query Bus, Event Store, and Event Scheduler. These factories allow you to configure and customize the behavior of these components for each tenant.
 
 The following tenant segment factories are available:
 


### PR DESCRIPTION
This PR fixes an issue where multiple tenants shared a single SimpleCommandBus instance, causing problems with handler interceptor duplication.

Added tests to verify unique SimpleCommandBus instances per tenant and correct handler interceptor application.