### PR TITLE
[#215] Fix: Reverse Component Deregistration Order in AxonServerTenantProvider

### DIFF
--- a/multitenancy-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/multitenancy/autoconfig/AxonServerTenantProvider.java
+++ b/multitenancy-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/multitenancy/autoconfig/AxonServerTenantProvider.java
@@ -238,9 +238,29 @@ public class AxonServerTenantProvider implements TenantProvider, Lifecycle {
         lifecycle.onShutdown(Phase.INSTRUCTION_COMPONENTS + 10, this::shutdown);
     }
 
-    private void shutdown() {
-        registrationMap.forEach((tenant, registrationList) -> {
-            registrationList.forEach(Registration::cancel);
+    /**
+     * Shuts down the AxonServerTenantProvider by deregistering all subscribed components.
+     * This method is designed to be invoked by a lifecycle handler (e.g., a shutdown hook)
+     * to ensure proper cleanup when the application is shutting down.
+     * <p>
+     * The shutdown process involves the following steps:
+     * <ol>
+     *     <li>Iterates through all registered components for each tenant.</li>
+     *     <li>Reverses the order of registrations for each tenant to ensure
+     *         last-registered components are deregistered first.</li>
+     *     <li>Invokes the cancel method on each registration, effectively
+     *         deregistering the component from the tenant.</li>
+     * </ol>
+     * <p>
+     * This method ensures that all resources associated with tenant management are properly
+     * released and that components are given the opportunity to perform any necessary cleanup
+     * in the reverse order of their registration.
+     */
+    public void shutdown() {
+        registrationMap.values().forEach(registrationList -> {
+            ArrayList<Registration> reversed = new ArrayList<>(registrationList);
+            Collections.reverse(reversed);
+            reversed.forEach(Registration::cancel);
         });
     }
 }


### PR DESCRIPTION
Originally issue is reported [here](https://discuss.axoniq.io/t/multitenancy-extension-shutdown-handler/5654/9) as issue with shutdown handler introduction. After reproducing the issue, its found that issue is actually in AxonServerTenantProvider shutdown method.

## Problem

The current implementation of the `shutdown()` method in `AxonServerTenantProvider` deregisters components in the same order they were registered. This can lead to potential issues during application shutdown, as components that depend on others might be deregistered before the components they depend on.

## Solution

This PR modifies the `shutdown()` method to deregister components in the reverse order of their registration. This ensures that components are shut down in a proper sequence, allowing for any necessary cleanup operations to occur in the correct order.

## Changes

1. Modified the `shutdown()` method in `AxonServerTenantProvider`:
   - Now reverses the list of registrations for each tenant before cancelling them.
   - This ensures that the last registered component is the first to be deregistered.

2. Added unit tests to verify the correct shutdown order.

3. Updated JavaDoc for the `shutdown()` method to reflect its behavior and intended use.

## Testing

- Added new unit test `whenShutdownThenDeregisterComponentsInReverseOrder()` to verify the correct deregistration order.


This PR resolves #215.