### PR TITLE
Pass through missing span factories

### DIFF
--- a/multitenancy-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/multitenancy/autoconfig/MultiTenancyAxonServerAutoConfiguration.java
+++ b/multitenancy-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/multitenancy/autoconfig/MultiTenancyAxonServerAutoConfiguration.java
@@ -30,6 +30,7 @@ import org.axonframework.commandhandling.*;
 import org.axonframework.commandhandling.distributed.RoutingStrategy;
 import org.axonframework.common.transaction.TransactionManager;
 import org.axonframework.config.Configuration;
+import org.axonframework.eventhandling.EventBusSpanFactory;
 import org.axonframework.extensions.multitenancy.components.TenantConnectPredicate;
 import org.axonframework.extensions.multitenancy.components.TenantDescriptor;
 import org.axonframework.extensions.multitenancy.components.TenantEventProcessorControlSegmentFactory;
@@ -130,6 +131,7 @@ public class MultiTenancyAxonServerAutoConfiguration {
                                                                   .routingStrategy(routingStrategy)
                                                                   .priorityCalculator(priorityCalculator)
                                                                   .loadFactorProvider(loadFactorProvider)
+                                                                  .spanFactory(axonConfiguration.getComponent(CommandBusSpanFactory.class))
                                                                   .targetContextResolver(targetContextResolver)
                                                                   .axonServerConnectionManager(connectionManager)
                                                                   .configuration(axonServerConfig)
@@ -163,6 +165,7 @@ public class MultiTenancyAxonServerAutoConfiguration {
                                           QueryBus.class, "queryBus@" + tenantDescriptor
                                   ))
                                   .transactionManager(txManager)
+                                  .spanFactory(config.getComponent(QueryBusSpanFactory.class))
                                   .queryUpdateEmitter(multiTenantQueryUpdateEmitter)
                                   .errorHandler(queryInvocationErrorHandler)
                                   .build();
@@ -183,6 +186,7 @@ public class MultiTenancyAxonServerAutoConfiguration {
                                       .messageSerializer(messageSerializer)
                                       .genericSerializer(genericSerializer)
                                       .priorityCalculator(priorityCalculator)
+                                      .spanFactory(config.getComponent(QueryBusSpanFactory.class))
                                       .targetContextResolver(targetContextResolver)
                                       .defaultContext(tenantDescriptor.tenantId())
                                       .build();
@@ -224,6 +228,7 @@ public class MultiTenancyAxonServerAutoConfiguration {
                                        .platformConnectionManager(axonServerConnectionManager)
                                        .snapshotSerializer(snapshotSerializer)
                                        .eventSerializer(eventSerializer)
+                                       .spanFactory(config.getComponent(EventBusSpanFactory.class))
                                        .defaultContext(tenant.tenantId())
                                        .snapshotFilter(config.snapshotFilter())
                                        .upcasterChain(config.upcasterChain())

--- a/multitenancy/src/main/java/org/axonframework/extensions/multitenancy/configuration/MultiTenantEventProcessingModule.java
+++ b/multitenancy/src/main/java/org/axonframework/extensions/multitenancy/configuration/MultiTenantEventProcessingModule.java
@@ -21,14 +21,7 @@ import org.axonframework.common.transaction.TransactionManager;
 import org.axonframework.config.Configuration;
 import org.axonframework.config.EventProcessingConfigurer;
 import org.axonframework.config.EventProcessingModule;
-import org.axonframework.eventhandling.DirectEventProcessingStrategy;
-import org.axonframework.eventhandling.EventHandlerInvoker;
-import org.axonframework.eventhandling.EventMessage;
-import org.axonframework.eventhandling.EventProcessor;
-import org.axonframework.eventhandling.SubscribingEventProcessor;
-import org.axonframework.eventhandling.TrackedEventMessage;
-import org.axonframework.eventhandling.TrackingEventProcessor;
-import org.axonframework.eventhandling.TrackingEventProcessorConfiguration;
+import org.axonframework.eventhandling.*;
 import org.axonframework.eventhandling.pooled.PooledStreamingEventProcessor;
 import org.axonframework.extensions.multitenancy.TenantWrappedTransactionManager;
 import org.axonframework.extensions.multitenancy.components.eventstore.MultiTenantSubscribableMessageSource;
@@ -204,6 +197,7 @@ public class MultiTenantEventProcessingModule extends EventProcessingModule {
                                         .rollbackConfiguration(super.rollbackConfiguration(name))
                                         .errorHandler(super.errorHandler(name))
                                         .messageMonitor(super.messageMonitor(SubscribingEventProcessor.class, name))
+                                        .spanFactory(super.configuration.getComponent(EventProcessorSpanFactory.class))
                                         .messageSource(source)
                                         .processingStrategy(DirectEventProcessingStrategy.INSTANCE)
                                         .transactionManager(transactionManager)
@@ -260,6 +254,7 @@ public class MultiTenantEventProcessingModule extends EventProcessingModule {
                                      .rollbackConfiguration(super.rollbackConfiguration(name))
                                      .errorHandler(super.errorHandler(name))
                                      .messageMonitor(super.messageMonitor(TrackingEventProcessor.class, name))
+                                     .spanFactory(super.configuration.getComponent(EventProcessorSpanFactory.class))
                                      .messageSource(source)
                                      .tokenStore(super.tokenStore(name))
                                      .transactionManager(transactionManager)
@@ -339,6 +334,7 @@ public class MultiTenantEventProcessingModule extends EventProcessingModule {
                                             .errorHandler(super.errorHandler(name))
                                             .messageMonitor(super.messageMonitor(PooledStreamingEventProcessor.class, name))
                                             .messageSource(source)
+                                            .spanFactory(super.configuration.getComponent(EventProcessorSpanFactory.class))
                                             .tokenStore(super.tokenStore(name))
                                             .transactionManager(transactionManager)
                                             .coordinatorExecutor(processorName -> {


### PR DESCRIPTION
Solves the issue of missing span factories not being passed through, thus enabling anything that relies on Spans to correctly work when used with Multitenancy extension